### PR TITLE
Add opt-in protocol CasePathSubscriptable to add similar functionality to struct keyPath subscripts

### DIFF
--- a/Sources/CasePaths/CasePathSubscriptable.swift
+++ b/Sources/CasePaths/CasePathSubscriptable.swift
@@ -1,0 +1,10 @@
+public protocol CasePathSubscriptable {}
+
+/// Opt in protocol to allow subscripting of case paths in a similar way to key paths on structs
+public extension CasePathSubscriptable {
+  subscript <T>(casePath casePath: CasePath<Self, T>) -> T? {
+    get {
+      return casePath.extract(from: self)
+    }
+  }
+}

--- a/Sources/CasePaths/CasePathSubscriptable.swift
+++ b/Sources/CasePaths/CasePathSubscriptable.swift
@@ -2,6 +2,10 @@ public protocol CasePathSubscriptable {}
 
 /// Opt in protocol to allow subscripting of case paths in a similar way to key paths on structs
 public extension CasePathSubscriptable {
+  /// Attempts to extract a value from an enum
+  ///
+  /// - Parameter casePath: a case path for this enum
+  /// - Returns: A value iff it can be extracted from the given root, otherwise `nil`.
   subscript <T>(casePath casePath: CasePath<Self, T>) -> T? {
     get {
       return casePath.extract(from: self)

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -342,6 +342,26 @@ final class CasePathsTests: XCTestCase {
     XCTAssertEqual(Foo.bar(12)[casePath: /Foo.bar], 12)
     XCTAssertEqual(Foo.bar(12)[casePath: /Foo.baz], nil)
   }
+  
+  func testNestedCasePathSubscriptable() {
+    enum EnumA: CasePathSubscriptable {
+      case one(EnumB)
+      case two(EnumC)
+    }
+    
+    enum EnumB: CasePathSubscriptable {
+      case one(Int)
+      case two(String)
+    }
+    
+    enum EnumC: CasePathSubscriptable {
+      case one(Int)
+    }
+    
+    XCTAssertEqual(EnumA.one(EnumB.one(12))[casePath: /EnumA.one .. /EnumB.one], 12)
+    XCTAssertEqual(EnumA.one(EnumB.one(12))[casePath: /EnumA.one .. /EnumB.two], nil)
+    XCTAssertEqual(EnumA.two(EnumC.one(12))[casePath: /EnumA.one .. /EnumB.one], nil)
+  }
 
 //  func testStructs() {
 //    struct Point { var x: Double, y: Double }

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -332,6 +332,16 @@ final class CasePathsTests: XCTestCase {
     XCTAssertNil((/EnumWithLabeledCase.labeled(label:otherLabel:)).extract(from: .labeled(2, 2)))
     XCTAssertNotNil((/EnumWithLabeledCase.labeled(label:otherLabel:)).extract(from: .labeled(label: 2, otherLabel: 2)))
   }
+  
+  func testCasePathSubscriptable() {
+    enum Foo: CasePathSubscriptable {
+      case bar(Int)
+      case baz(String)
+    }
+    
+    XCTAssertEqual(Foo.bar(12)[casePath: /Foo.bar], 12)
+    XCTAssertEqual(Foo.bar(12)[casePath: /Foo.baz], nil)
+  }
 
 //  func testStructs() {
 //    struct Point { var x: Double, y: Double }

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -343,6 +343,32 @@ final class CasePathsTests: XCTestCase {
     XCTAssertEqual(Foo.bar(12)[casePath: /Foo.baz], nil)
   }
   
+  func testMultiValueCasePathSubscriptable() {
+    enum Foo: CasePathSubscriptable {
+      case bar(Int, Int)
+      case baz(String)
+    }
+    
+    let test0 = Foo.bar(12, 42)[casePath: /Foo.bar]
+    XCTAssertEqual(test0!.0, 12)
+    XCTAssertEqual(test0!.1, 42)
+    let test1 = Foo.bar(12, 42)[casePath: /Foo.baz]
+    XCTAssertEqual(test1, nil)
+  }
+  
+  func testNamedMultiValueCasePathSubscriptable() {
+    enum Foo: CasePathSubscriptable {
+      case bar(a: Int, b: Int)
+      case baz(String)
+    }
+    
+    let test0 = Foo.bar(a: 12, b: 42)[casePath: /Foo.bar]
+    XCTAssertEqual(test0!.0, 12)
+    XCTAssertEqual(test0!.1, 42)
+    let test1 = Foo.bar(a: 12, b: 42)[casePath: /Foo.baz]
+    XCTAssertEqual(test1, nil)
+  }
+  
   func testNestedCasePathSubscriptable() {
     enum EnumA: CasePathSubscriptable {
       case one(EnumB)


### PR DESCRIPTION
Hey there! Love this library. One thing kept eating at me and it was exemplified by these lines from the README:

```swift
user[keyPath: \User.id] // 42
(/Authentication.authenticated).extract(from: authentication) // Optional("cafebeef")
```

These feel asymmetrical, and I don't think they need to be. With a protocol extension we can define a subscript that looks almost identical to structs.

```swift
user[keyPath: \User.id] // 42
authentication[casePath: /Authentication.authenticated] // Optional("cafebeef")
```

Voila! It's also opt in so, like the operators in the library, completely ignorable if so desired.

One reservation I have is that someone could apply this protocol to something other than an enum, which would have unexpected and undefined behaviors. However, I think this is fundamentally similar to the limitations of the library in general and just the limitations of implementing this at the 3rd party library level.