### PR TITLE
Change package name capitalization

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 import PackageDescription
 
 let package = Package(
-  name: "CasePaths",
+  name: "case-paths",
   products: [
     .library(
       name: "CasePaths",


### PR DESCRIPTION
I know this is ballsy, but I would like to propose changing the package name to match the capitalization used in the official packages as well as other platform-agnostic 3rd party libraries. I understand if you'd rather stick to the convention used within iOS circles, in which case feel free to close this PR.