### PR TITLE
Case Path Shorthand Syntax

### DIFF
--- a/Sources/CasePaths/Operators.swift
+++ b/Sources/CasePaths/Operators.swift
@@ -32,6 +32,16 @@ public prefix func / <Root>(
   .self
 }
 
+/// Identifies and returns a given case path. Enables shorthand syntax on static case paths, _e.g._ `/.self`  instead of `.self`.
+///
+/// - Parameter type: A type for which to return the identity case path.
+/// - Returns: An identity case path.
+public prefix func / <Root>(
+  type: CasePath<Root, Root>
+) -> CasePath<Root, Root> {
+  .self
+}
+
 /// Returns a function that can attempt to extract associated values from the given enum case initializer.
 ///
 /// Use this operator to create new transform functions to pass to higher-order methods like `compactMap`:

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -65,6 +65,12 @@ final class CasePathsTests: XCTestCase {
 
     XCTAssertEqual(
       .some(42),
+      (/.self)
+        .extract(from: 42)
+    )
+
+    XCTAssertEqual(
+      .some(42),
       (/{ $0 })
         .extract(from: 42)
     )


### PR DESCRIPTION
After using case paths in projects where they often appear alongside key paths, it's nice to be able to annotate them with `/` as often as possible. This PR introduces an "identity" `/` operator for case paths to unlock this ability.

For example, in interfaces that take key paths and case paths, it is common to leave either fixed. For state this is straightforward:

``` swift
// Leave state fixed
reducer.pullback(state: \.self, action: /SuperAction.subAction)
```

For actions, you have a couple choices:

``` swift
// Leave action fixed with static `self`. No `/` identifying the case path
reducer.pullback(state: \SuperState.subState, action: .self)

// Leave action fixed with "long"-hand syntax. Trick uses operator overload on `Enum.Type`
reducer.pullback(state: \SuperState.subState, action: /SubAction.self)
```

The latter is needlessly verbose while the former loses the balance of `\` and `/` and annotation the latter provides.

With an additional overload we allow for this:

``` swift
// Leave action fixed with case path annotation operator
reducer.pullback(state: \SuperState.subState, action: /.self)
```

This shorthand extends to any static case path.

``` swift
/.never         // The "never" key path
/.rawValue      // For `RawRepresentable`
/.description   // For `LosslessStringConvertible`
```

The downside is another operator overload, but it doesn't seem to conflict.
