### PR TITLE
Work around SPM bugs with static libraries

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,7 @@ let package = Package(
   products: [
     .library(
       name: "CasePaths",
+      type: .dynamic,
       targets: ["CasePaths"]),
   ],
   dependencies: [],

--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,9 @@ let package = Package(
   products: [
     .library(
       name: "CasePaths",
+      targets: ["CasePaths"]),
+    .library(
+      name: "CasePaths-dynamic",
       type: .dynamic,
       targets: ["CasePaths"]),
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 import PackageDescription
 
 let package = Package(
-  name: "CasePaths",
+  name: "swift-case-paths",
   products: [
     .library(
       name: "CasePaths",


### PR DESCRIPTION
This adds another library, `CasePath-dynamic`, so that we can work around some SPM bugs.