### PR TITLE
Improve value extraction performance using `hashValue` when available

### DIFF
--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -67,7 +67,10 @@ public func extract<Root, Value>(case embed: (Value) -> Root, from root: Root) -
       any = anyChild
     }
     if MemoryLayout<Value>.size == 0, !isUninhabitedEnum(Value.self) {
-      return (["\(root)"], unsafeBitCast((), to: Value.self))
+      // If `any` is hashable, using its `hashValue` as path component is 
+      // likely faster than describing `any` itself.
+      let path = [String(describing: (any as? AnyHashable)?.hashValue ?? any)]
+      return (path, unsafeBitCast((), to: Value.self))
     }
     return nil
   }

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -67,8 +67,8 @@ public func extract<Root, Value>(case embed: (Value) -> Root, from root: Root) -
       any = anyChild
     }
     if MemoryLayout<Value>.size == 0, !isUninhabitedEnum(Value.self) {
-      // If `any` is hashable, using its `hashValue` as path component is 
-      // likely faster than describing `any` itself.
+      // If `root` is hashable, using its `hashValue` as path component is 
+      // likely faster than describing `root` itself.
       let path = [String(describing: (root as? AnyHashable)?.hashValue ?? root as Any)]
       return (path, unsafeBitCast((), to: Value.self))
     }

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -69,7 +69,7 @@ public func extract<Root, Value>(case embed: (Value) -> Root, from root: Root) -
     if MemoryLayout<Value>.size == 0, !isUninhabitedEnum(Value.self) {
       // If `any` is hashable, using its `hashValue` as path component is 
       // likely faster than describing `any` itself.
-      let path = [String(describing: (any as? AnyHashable)?.hashValue ?? any)]
+      let path = [String(describing: (root as? AnyHashable)?.hashValue ?? root as Any)]
       return (path, unsafeBitCast((), to: Value.self))
     }
     return nil

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -364,6 +364,22 @@ final class CasePathsTests: XCTestCase {
       (/EnumWithLabeledCase.labeled(label:otherLabel:)).extract(
         from: .labeled(label: 2, otherLabel: 2)))
   }
+  
+  func testSiblingCases() {
+    enum Parent {
+      case foo(Foo)
+      case bar(Bar)
+    }
+    enum Foo {
+      case value(Int)
+    }
+    enum Bar {
+      case unrelated
+    }
+    XCTAssertNil(
+      extract(case: { Parent.bar(.unrelated) }, from: Parent.foo(.value(42)) )
+    )
+  }
 
   //  func testStructs() {
   //    struct Point { var x: Double, y: Double }


### PR DESCRIPTION
This pull request tries to improve the issue  #17.
While extracting the value from a case initializer using reflection, describing `any` as a String without precaution can cause performance issues when the value's description is very long, like it happens for large arrays or dictionaries for example.
In this cases, using a more compact marker is preferable. A common candidate is the hashValue of Hashable values. 
Thus, when `any` is Hashable, the library now uses its `hashValue` instead of the value itself as a path component. In other cases, it uses `any` description.

_Please note that if `hashValue` is now deprecated as Hashable requirement, it is very unlikely it will be ever removed. In any case, it can be reimplemented as_
```
extension Hashable {
    var hashValueCompat: Int {
        var hasher = Hasher()
        hasher.combine(self)
        return hasher.finalize()
    }
}
```
_This is the same implementation used in Swift's [Hashable.swift](https://github.com/apple/swift/blob/main/stdlib/public/core/Hashable.swift)._