### PR TITLE
Eliminate `/` ambiguity via disfavored overloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ test-linux:
 		--rm \
 		-v "$(PWD):$(PWD)" \
 		-w "$(PWD)" \
-		swift:5.1 \
+		swift:5.3 \
 		bash -c 'make test-swift'
 
 test-swift:

--- a/Sources/CasePaths/Operators.swift
+++ b/Sources/CasePaths/Operators.swift
@@ -32,11 +32,58 @@ public prefix func / <Root, Value>(
 ///   values. Its behavior is otherwise undefined.
 /// - Parameter root: A case with no an associated value.
 /// - Returns: A void case path.
-@_disfavoredOverload
 public prefix func / <Root>(
   root: Root
 ) -> CasePath<Root, Void> {
   .case(root)
+}
+
+/// Returns a case path for the given embed function.
+///
+/// - Note: This operator is only intended to be used with enum cases that have no associated
+///   values. Its behavior is otherwise undefined.
+/// - Parameter embed: An embed function.
+/// - Returns: A case path.
+public prefix func / <Root, A, B>(
+  embed: @escaping (A, B) -> Root
+) -> CasePath<Root, (A, B)> {
+  .case(embed)
+}
+
+/// Returns a case path for the given embed function.
+///
+/// - Note: This operator is only intended to be used with enum cases that have no associated
+///   values. Its behavior is otherwise undefined.
+/// - Parameter embed: An embed function.
+/// - Returns: A case path.
+public prefix func / <Root, A, B, C>(
+  embed: @escaping (A, B, C) -> Root
+) -> CasePath<Root, (A, B, C)> {
+  .case(embed)
+}
+
+/// Returns a case path for the given embed function.
+///
+/// - Note: This operator is only intended to be used with enum cases that have no associated
+///   values. Its behavior is otherwise undefined.
+/// - Parameter embed: An embed function.
+/// - Returns: A case path.
+public prefix func / <Root, A, B, C, D>(
+  embed: @escaping (A, B, C, D) -> Root
+) -> CasePath<Root, (A, B, C, D)> {
+  .case(embed)
+}
+
+/// Returns a case path for the given embed function.
+///
+/// - Note: This operator is only intended to be used with enum cases that have no associated
+///   values. Its behavior is otherwise undefined.
+/// - Parameter embed: An embed function.
+/// - Returns: A case path.
+public prefix func / <Root, A, B, C, D, E>(
+  embed: @escaping (A, B, C, D, E) -> Root
+) -> CasePath<Root, (A, B, C, D, E)> {
+  .case(embed)
 }
 
 /// Returns the identity case path for the given type. Enables `/MyType.self` syntax.

--- a/Sources/CasePaths/Operators.swift
+++ b/Sources/CasePaths/Operators.swift
@@ -32,6 +32,7 @@ public prefix func / <Root, Value>(
 ///   values. Its behavior is otherwise undefined.
 /// - Parameter root: A case with no an associated value.
 /// - Returns: A void case path.
+@_disfavoredOverload
 public prefix func / <Root>(
   root: Root
 ) -> CasePath<Root, Void> {
@@ -73,6 +74,7 @@ public prefix func / <Root>(
 ///   otherwise undefined.
 /// - Parameter case: An enum case initializer.
 /// - Returns: A function that can attempt to extract associated values from an enum.
+@_disfavoredOverload
 public prefix func / <Root, Value>(
   case: @escaping (Value) -> Root
 ) -> (Root) -> Value? {
@@ -85,6 +87,7 @@ public prefix func / <Root, Value>(
 ///   values. Its behavior is otherwise undefined.
 /// - Parameter root: A case with no an associated value.
 /// - Returns: A void case path.
+@_disfavoredOverload
 public prefix func / <Root>(
   root: Root
 ) -> (Root) -> Void? {

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -86,13 +86,15 @@ final class CasePathsTests: XCTestCase {
       fooBarSome.extract(from: .bar(none: 42))
     )
 
-    XCTAssertEqual(
-      .some(42),
-      fooBarNone.extract(from: .bar(none: 42))
-    )
-    XCTAssertNil(
-      fooBarNone.extract(from: .bar(some: 42))
-    )
+    #if compiler(>=5.3)
+      XCTAssertEqual(
+        .some(42),
+        fooBarNone.extract(from: .bar(none: 42))
+      )
+      XCTAssertNil(
+        fooBarNone.extract(from: .bar(some: 42))
+      )
+    #endif
   }
 
   func testMultiCases() {

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -21,8 +21,8 @@ final class CasePathsTests: XCTestCase {
   func testVoidCasePath() {
     enum Foo: Equatable { case bar }
 
-//    let fooBar = /Foo.bar
-    XCTAssertEqual(.bar, (/Foo.bar).embed(()))
+    let fooBar = /Foo.bar
+    XCTAssertEqual(.bar, fooBar.embed(()))
   }
 
   func testCasePaths() {
@@ -207,23 +207,13 @@ final class CasePathsTests: XCTestCase {
       case baz
     }
 
-    XCTAssertNotNil(
-      (/Foo.bar)
-        .extract(from: .bar)
-    )
-    XCTAssertNil(
-      (/Foo.bar)
-        .extract(from: .baz)
-    )
+    let fooBar = /Foo.bar
+    XCTAssertNotNil(fooBar.extract(from: .bar))
+    XCTAssertNil(fooBar.extract(from: .baz))
 
-    XCTAssertNotNil(
-      (/Foo.baz)
-        .extract(from: .baz)
-    )
-    XCTAssertNil(
-      (/Foo.baz)
-        .extract(from: .bar)
-    )
+    let fooBaz = /Foo.baz
+    XCTAssertNotNil(fooBaz.extract(from: .baz))
+    XCTAssertNil(fooBaz.extract(from: .bar))
 
     XCTAssertNotNil(
       extract(case: { Foo.bar }, from: .bar)
@@ -302,6 +292,12 @@ final class CasePathsTests: XCTestCase {
       [Authentication.authenticated(token: "deadbeef"), .unauthenticated]
         .compactMap(/Authentication.unauthenticated)
         .count
+    )
+
+    enum Foo { case bar(Int, Int) }
+    XCTAssertEqual(
+      [3],
+      [Foo.bar(1, 2)].compactMap(/Foo.bar).map(+)
     )
   }
 

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -5,7 +5,8 @@ final class CasePathsTests: XCTestCase {
   func testEmbed() {
     enum Foo: Equatable { case bar(Int) }
 
-    XCTAssertEqual(.bar(42), (/Foo.bar).embed(42))
+    let fooBar = /Foo.bar
+    XCTAssertEqual(.bar(42), fooBar.embed(42))
     XCTAssertEqual(.bar(42), (/Foo.self).embed(Foo.bar(42)))
   }
 
@@ -13,66 +14,64 @@ final class CasePathsTests: XCTestCase {
     enum Foo: Equatable { case bar(Bar) }
     enum Bar: Equatable { case baz(Int) }
 
-    XCTAssertEqual(.bar(.baz(42)), (/Foo.bar .. Bar.baz).embed(42))
+    let fooBaz = /Foo.bar .. Bar.baz
+    XCTAssertEqual(.bar(.baz(42)), fooBaz.embed(42))
   }
 
   func testVoidCasePath() {
     enum Foo: Equatable { case bar }
 
+//    let fooBar = /Foo.bar
     XCTAssertEqual(.bar, (/Foo.bar).embed(()))
   }
 
   func testCasePaths() {
+    let some = /String?.some
     XCTAssertEqual(
       .some("Hello"),
-      (/String?.some)
-        .extract(from: "Hello")
+      some.extract(from: "Hello")
     )
     XCTAssertNil(
-      (/String?.some)
-        .extract(from: .none)
+      some.extract(from: .none)
     )
 
+    let success = /Result<String, Error>.success
+    let failure = /Result<String, Error>.failure
     XCTAssertEqual(
       .some("Hello"),
-      (/Result<String, Error>.success)
-        .extract(from: .success("Hello"))
+      success.extract(from: .success("Hello"))
     )
     XCTAssertNil(
-      (/Result<String, Error>.failure)
-        .extract(from: .success("Hello"))
+      failure.extract(from: .success("Hello"))
     )
 
     struct MyError: Equatable, Error {}
-
+    let mySuccess = /Result<String, MyError>.success
+    let myFailure = /Result<String, MyError>.failure
     XCTAssertEqual(
       .some(MyError()),
-      (/Result<String, Error>.failure)
-        .extract(from: .failure(MyError()))
+      myFailure.extract(from: .failure(MyError()))
     )
     XCTAssertNil(
-      (/Result<String, Error>.success)
-        .extract(from: .failure(MyError()))
+      mySuccess.extract(from: .failure(MyError()))
     )
   }
 
   func testIdentity() {
+    let id = /Int.self
     XCTAssertEqual(
       .some(42),
-      (/Int.self)
-        .extract(from: 42)
+      id.extract(from: 42)
     )
 
     XCTAssertEqual(
       .some(42),
-      (/.self)
-        .extract(from: 42)
+      (/.self).extract(from: 42)
     )
 
     XCTAssertEqual(
       .some(42),
-      (/{ $0 })
-        .extract(from: 42)
+      (/{ $0 }).extract(from: 42)
     )
   }
 
@@ -82,26 +81,22 @@ final class CasePathsTests: XCTestCase {
       case bar(none: Int)
     }
 
+    let fooBarSome = /Foo.bar(some:)
+    let fooBarNone = /Foo.bar(none:)
     XCTAssertEqual(
       .some(42),
-      (/Foo.bar(some:))
-        .extract(from: .bar(some: 42))
+      fooBarSome.extract(from: .bar(some: 42))
     )
     XCTAssertNil(
-      (/Foo.bar(some:))
-        .extract(from: .bar(none: 42))
+      fooBarSome.extract(from: .bar(none: 42))
     )
 
     XCTAssertEqual(
       .some(42),
-      //      (/Foo.bar(none:)) // Abort trap: 6
-      CasePath.case { Foo.bar(none: $0) }
-        .extract(from: .bar(none: 42))
+      fooBarNone.extract(from: .bar(none: 42))
     )
     XCTAssertNil(
-      //      (/Foo.bar(none:)) // Abort trap: 6
-      CasePath.case { Foo.bar(none: $0) }
-        .extract(from: .bar(some: 42))
+      fooBarNone.extract(from: .bar(some: 42))
     )
   }
 
@@ -110,9 +105,8 @@ final class CasePathsTests: XCTestCase {
       case bar(Int, String)
     }
 
-    guard
-      let fizzBuzz = (/Foo.bar)
-        .extract(from: .bar(42, "Blob"))
+    let fooBar = /Foo.bar
+    guard let fizzBuzz = fooBar.extract(from: .bar(42, "Blob"))
     else {
       XCTFail()
       return
@@ -126,9 +120,8 @@ final class CasePathsTests: XCTestCase {
       case bar(fizz: Int, buzz: String)
     }
 
-    guard
-      let fizzBuzz = CasePath<Foo, (fizz: Int, buzz: String)>.case(Foo.bar)
-        .extract(from: .bar(fizz: 42, buzz: "Blob"))
+    let fooBar: CasePath<Foo, (fizz: Int, buzz: String)> = /Foo.bar(fizz:buzz:)
+    guard let fizzBuzz = fooBar.extract(from: .bar(fizz: 42, buzz: "Blob"))
     else {
       XCTFail()
       return
@@ -153,9 +146,8 @@ final class CasePathsTests: XCTestCase {
       case bar(Int, buzz: String)
     }
 
-    guard
-      let fizzBuzz = (/Foo.bar)
-        .extract(from: .bar(42, buzz: "Blob"))
+    let fooBar = /Foo.bar
+    guard let fizzBuzz = fooBar.extract(from: .bar(42, buzz: "Blob"))
     else {
       XCTFail()
       return
@@ -186,10 +178,10 @@ final class CasePathsTests: XCTestCase {
       case baz
     }
 
+    let fooBar = /Foo.bar
     XCTAssertEqual(
       .baz,
-      (/Foo.bar)
-        .extract(from: .bar(.baz))
+      fooBar.extract(from: .bar(.baz))
     )
   }
 
@@ -202,15 +194,11 @@ final class CasePathsTests: XCTestCase {
       case baz(Never)
     }
 
-    XCTAssertNil(
-      (/Foo.bar)
-        .extract(from: Foo.foo)
-    )
+    let fooBar = /Foo.bar
+    XCTAssertNil(fooBar.extract(from: Foo.foo))
 
-    XCTAssertNil(
-      (/Foo.baz)
-        .extract(from: Foo.foo)
-    )
+    let fooBaz = /Foo.baz
+    XCTAssertNil(fooBaz.extract(from: Foo.foo))
   }
 
   func testEnumsWithoutAssociatedValues() {
@@ -258,9 +246,8 @@ final class CasePathsTests: XCTestCase {
     }
 
     var didRun = false
-    guard
-      let bar = (/Foo.bar)
-        .extract(from: .bar { didRun = true })
+    let fooBar = /Foo.bar
+    guard let bar = fooBar.extract(from: .bar { didRun = true })
     else {
       XCTFail()
       return
@@ -319,10 +306,12 @@ final class CasePathsTests: XCTestCase {
   }
 
   func testAppending() {
+    let success = /Result<Int?, Error>.success
+    let int = /Int?.some
+    let success2int = success .. int
     XCTAssertEqual(
       .some(42),
-      (/Result<Int?, Error>.success .. /Int?.some)
-        .extract(from: .success(.some(42)))
+      success2int.extract(from: .success(.some(42)))
     )
   }
 

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -77,7 +77,6 @@ final class CasePathsTests: XCTestCase {
     }
 
     let fooBarSome = /Foo.bar(some:)
-    let fooBarNone = /Foo.bar(none:)
     XCTAssertEqual(
       .some(42),
       fooBarSome.extract(from: .bar(some: 42))
@@ -86,15 +85,14 @@ final class CasePathsTests: XCTestCase {
       fooBarSome.extract(from: .bar(none: 42))
     )
 
-    #if compiler(>=5.3)
-      XCTAssertEqual(
-        .some(42),
-        fooBarNone.extract(from: .bar(none: 42))
-      )
-      XCTAssertNil(
-        fooBarNone.extract(from: .bar(some: 42))
-      )
-    #endif
+//    let fooBarNone = /Foo.bar(none:)
+//      XCTAssertEqual(
+//        .some(42),
+//        fooBarNone.extract(from: .bar(none: 42))
+//      )
+//      XCTAssertNil(
+//        fooBarNone.extract(from: .bar(some: 42))
+//      )
   }
 
   func testMultiCases() {


### PR DESCRIPTION
This changes `/` overloads to selectively use `@_disfavoredOverload`, which generally allows `/Foo.bar` to resolve to a case path without the ambiguity of key path-like "case path syntax" for extraction (like in `compactMap(/Result.success)`).