### PR TITLE
Breaking Change: Simplify Reflection

### DIFF
--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -57,6 +57,7 @@ public func extract<Root, Value>(case embed: (Value) -> Root, from root: Root) -
       let value = child.value as? Value ?? childMirror.children.first?.value as? Value
     else {
       #if compiler(<5.2)
+        // https://bugs.swift.org/browse/SR-12044
         if MemoryLayout<Value>.size == 0, !isUninhabitedEnum(Value.self) {
           return (["\(root)"], unsafeBitCast((), to: Value.self))
         }

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -86,9 +86,9 @@ public func extract<Root, Value>(case embed: (Value) -> Root, from root: Root) -
 ///
 /// - Note: This function is only intended to be used with enum case initializers. Its behavior is
 ///   otherwise undefined.
-/// - Parameter case: An enum case initializer.
+/// - Parameter embed: An enum case initializer.
 /// - Returns: A function that can attempt to extract associated values from an enum.
-public func extract<Root, Value>(_ case: @escaping (Value) -> Root) -> (Root) -> (Value?) {
+public func extract<Root, Value>(_ embed: @escaping (Value) -> Root) -> (Root) -> (Value?) {
   return { root in
     return extract(case: `case`, from: root)
   }

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -56,7 +56,7 @@ public func extract<Root, Value>(case embed: (Value) -> Root, from root: Root) -
       case let childMirror = Mirror(reflecting: child.value),
       let value = child.value as? Value ?? childMirror.children.first?.value as? Value
     else { return nil }
-    return ([childLabel] + childMirror.children.map(\.label), value)
+    return ([childLabel] + childMirror.children.map { $0.label }, value)
   }
   guard
     let (rootPath, value) = dump(extractHelp(from: root)),

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -47,7 +47,7 @@ extension CasePath where Value == Void {
 /// - Returns: Values iff they can be extracted from the given enum case initializer and root enum,
 ///   otherwise `nil`.
 public func extract<Root, Value>(case embed: (Value) -> Root, from root: Root) -> Value? {
-  func extractHelp(from root: Root) -> ([String?], Value)? {
+  func extractHelp(from root: Root) -> (path: [String?], value: Value)? {
     let mirror = Mirror(reflecting: root)
     assert(mirror.displayStyle == .enum || mirror.displayStyle == .optional)
     guard
@@ -90,7 +90,7 @@ public func extract<Root, Value>(case embed: (Value) -> Root, from root: Root) -
 /// - Returns: A function that can attempt to extract associated values from an enum.
 public func extract<Root, Value>(_ embed: @escaping (Value) -> Root) -> (Root) -> (Value?) {
   return { root in
-    return extract(case: `case`, from: root)
+    return extract(case: embed, from: root)
   }
 }
 

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -67,8 +67,8 @@ public func extract<Root, Value>(case embed: (Value) -> Root, from root: Root) -
     return ([childLabel] + childMirror.children.map { $0.label }, value)
   }
   guard
-    let (rootPath, value) = dump(extractHelp(from: root)),
-    let (embedPath, _) = dump(extractHelp(from: embed(value))),
+    let (rootPath, value) = extractHelp(from: root),
+    let (embedPath, _) = extractHelp(from: embed(value)),
     rootPath == embedPath
   else { return nil }
   return value

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -55,7 +55,14 @@ public func extract<Root, Value>(case embed: (Value) -> Root, from root: Root) -
       let childLabel = child.label,
       case let childMirror = Mirror(reflecting: child.value),
       let value = child.value as? Value ?? childMirror.children.first?.value as? Value
-    else { return nil }
+    else {
+      #if compiler(<5.2)
+        if MemoryLayout<Value>.size == 0, !isUninhabitedEnum(Value.self) {
+          return (["\(root)"], unsafeBitCast((), to: Value.self))
+        }
+      #endif
+      return nil
+    }
     return ([childLabel] + childMirror.children.map { $0.label }, value)
   }
   guard

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -68,12 +68,6 @@ final class CasePathsTests: XCTestCase {
       (/.self)
         .extract(from: 42)
     )
-
-    XCTAssertEqual(
-      .some(42),
-      (/{ $0 })
-        .extract(from: 42)
-    )
   }
 
   func testLabeledCases() {
@@ -90,18 +84,6 @@ final class CasePathsTests: XCTestCase {
     XCTAssertNil(
       (/Foo.bar(some:))
         .extract(from: .bar(none: 42))
-    )
-
-    XCTAssertEqual(
-      .some(42),
-      //      (/Foo.bar(none:)) // Abort trap: 6
-      CasePath.case { Foo.bar(none: $0) }
-        .extract(from: .bar(none: 42))
-    )
-    XCTAssertNil(
-      //      (/Foo.bar(none:)) // Abort trap: 6
-      CasePath.case { Foo.bar(none: $0) }
-        .extract(from: .bar(some: 42))
     )
   }
 
@@ -137,17 +119,6 @@ final class CasePathsTests: XCTestCase {
     XCTAssertEqual("Blob", fizzBuzz.buzz)
   }
 
-  func testSingleValueExtractionFromMultiple() {
-    enum Foo {
-      case bar(fizz: Int, buzz: String)
-    }
-
-    XCTAssertEqual(
-      .some(42),
-      extract(case: { Foo.bar(fizz: $0, buzz: "Blob") }, from: .bar(fizz: 42, buzz: "Blob"))
-    )
-  }
-
   func testMultiMixedCases() {
     enum Foo {
       case bar(Int, buzz: String)
@@ -162,20 +133,6 @@ final class CasePathsTests: XCTestCase {
     }
     XCTAssertEqual(42, fizzBuzz.0)
     XCTAssertEqual("Blob", fizzBuzz.1)
-  }
-
-  func testNestedReflection() {
-    enum Foo {
-      case bar(Bar)
-    }
-    enum Bar {
-      case baz(Int)
-    }
-
-    XCTAssertEqual(
-      42,
-      extract(case: { Foo.bar(.baz($0)) }, from: .bar(.baz(42)))
-    )
   }
 
   func testNestedZeroMemoryLayout() {
@@ -236,20 +193,6 @@ final class CasePathsTests: XCTestCase {
       (/Foo.baz)
         .extract(from: .bar)
     )
-
-    XCTAssertNotNil(
-      extract(case: { Foo.bar }, from: .bar)
-    )
-    XCTAssertNil(
-      extract(case: { Foo.bar }, from: .baz)
-    )
-
-    XCTAssertNotNil(
-      extract(case: { Foo.baz }, from: .baz)
-    )
-    XCTAssertNil(
-      extract(case: { Foo.baz }, from: .bar)
-    )
   }
 
   func testEnumsWithClosures() {
@@ -277,10 +220,10 @@ final class CasePathsTests: XCTestCase {
 
     XCTAssertEqual(
       .some(42),
-      extract(case: { Foo.foo(.foo(.foo(.bar($0)))) }, from: .foo(.foo(.foo(.bar(42)))))
+      (/Foo.foo .. /Foo.foo .. /Foo.foo .. /Foo.bar).extract(from: .foo(.foo(.foo(.bar(42)))))
     )
     XCTAssertNil(
-      extract(case: { Foo.foo(.foo(.foo(.bar($0)))) }, from: .foo(.foo(.bar(42))))
+      (/Foo.foo .. /Foo.foo .. /Foo.foo .. /Foo.bar).extract(from: .foo(.foo(.bar(42))))
     )
   }
 
@@ -384,27 +327,4 @@ final class CasePathsTests: XCTestCase {
       XCTFail()
     }
   }
-
-  //  func testStructs() {
-  //    struct Point { var x: Double, y: Double }
-  //
-  //    guard
-  //      let (x, y) = CasePath(Point.init(x:y:))
-  //        .extract(from: Point(x: 16, y: 8))
-  //      else {
-  //        XCTFail()
-  //        return
-  //    }
-  //
-  //    XCTAssertEqual(16, x)
-  //    XCTAssertEqual(8, y)
-  //
-  //    guard
-  //      let (x1, y2) = CasePath(Point.init(what:where:))
-  //        .extract(from: Point(x: 16, y: 8))
-  //      else {
-  //        XCTFail()
-  //        return
-  //    }
-  //  }
 }


### PR DESCRIPTION
Our reflection mechanism currently goes pretty far out of its way to handle cases that it probably shouldn't:

- We currently produce reflective identity case paths for the identity function:
    ```swift
    CasePath.self == CasePath.case { $0 }
    ```
    We should always prefer `.self`, which is faster.
- We currently produce reflective appended case paths by recursively traversing the root mirror:
    ```swift
    /A.b .. /B.c == CasePath.case { .b(.c($0)) }
    ```
    We should always prefer `..` (or `CasePath.appending(path:)`)
- We allow "holes" to be filled on multi-payload enum cases:
    ```swift
    CasePath.case { .color($0, "fill") }.extract(from: .foo(.red, "fill")) == .red
    ```
    We should not support this kind of extraction.

Reflection is already quite slow, so let's improve performance a little by shedding this functionality so that we support enum initializers. We don't advertise this additional functionality (outside unit tests), so it should be a relatively safe change to make. We also want to make this change to future-proof the library for alternative modes of extraction, e.g. runtime metadata.