### PR TITLE
Conform CasePath to CustomStringConvertible

### DIFF
--- a/Sources/CasePaths/CasePath.swift
+++ b/Sources/CasePaths/CasePath.swift
@@ -47,3 +47,9 @@ public struct CasePath<Root, Value> {
     )
   }
 }
+
+extension CasePath: CustomStringConvertible {
+  public var description: String {
+    "CasePath<\(Root.self), \(Value.self)>"
+  }
+}

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -323,4 +323,11 @@ final class CasePathsTests: XCTestCase {
       XCTFail()
     }
   }
+
+  func testCustomStringConvertible() {
+    XCTAssertEqual(
+      "\(/Result<String, Error>.success)",
+      "CasePath<Result<String, Error>, String>"
+    )
+  }
 }


### PR DESCRIPTION
Makes things a lil prettier when working with case paths in playgrounds, etc.