### PR TITLE
Improve reflection with Swift runtime and caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
-.swiftpm/
 /.build
 /Packages
 /*.xcodeproj

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/CasePaths.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/CasePaths.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1300"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CasePaths"
+               BuildableName = "CasePaths"
+               BlueprintName = "CasePaths"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CasePathsTests"
+               BuildableName = "CasePathsTests"
+               BlueprintName = "CasePathsTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CasePaths"
+            BuildableName = "CasePaths"
+            BlueprintName = "CasePaths"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/swift-case-paths-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/swift-case-paths-Package.xcscheme
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1300"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CasePaths"
+               BuildableName = "CasePaths"
+               BlueprintName = "CasePaths"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "swift-case-paths-benchmark"
+               BuildableName = "swift-case-paths-benchmark"
+               BlueprintName = "swift-case-paths-benchmark"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CasePathsTests"
+               BuildableName = "CasePathsTests"
+               BlueprintName = "CasePathsTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CasePathsTests"
+               BuildableName = "CasePathsTests"
+               BlueprintName = "CasePathsTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "swift-case-paths-benchmark"
+            BuildableName = "swift-case-paths-benchmark"
+            BlueprintName = "swift-case-paths-benchmark"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "swift-case-paths-benchmark"
+            BuildableName = "swift-case-paths-benchmark"
+            BlueprintName = "swift-case-paths-benchmark"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/swift-case-paths-benchmark.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/swift-case-paths-benchmark.xcscheme
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1300"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "swift-case-paths-benchmark"
+               BuildableName = "swift-case-paths-benchmark"
+               BlueprintName = "swift-case-paths-benchmark"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CasePathsTests"
+               BuildableName = "CasePathsTests"
+               BlueprintName = "CasePathsTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "swift-case-paths-benchmark"
+            BuildableName = "swift-case-paths-benchmark"
+            BlueprintName = "swift-case-paths-benchmark"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "swift-case-paths-benchmark"
+            BuildableName = "swift-case-paths-benchmark"
+            BlueprintName = "swift-case-paths-benchmark"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,7 +11,7 @@
         }
       },
       {
-        "package": "swift-benchmark",
+        "package": "Benchmark",
         "repositoryURL": "https://github.com/google/swift-benchmark",
         "state": {
           "branch": null,

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "state": {
+          "branch": null,
+          "revision": "986d191f94cec88f6350056da59c2e59e83d1229",
+          "version": "0.4.3"
+        }
+      },
+      {
+        "package": "swift-benchmark",
+        "repositoryURL": "https://github.com/google/swift-benchmark",
+        "state": {
+          "branch": null,
+          "revision": "8e0ef8bb7482ab97dcd2cd1d6855bd38921c345d",
+          "version": "0.1.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,10 @@ let package = Package(
     .library(
       name: "CasePaths",
       targets: ["CasePaths"]
-    )
+    ),
+  ],
+  dependencies: [
+    .package(url: "https://github.com/google/swift-benchmark", from: "0.1.0")
   ],
   targets: [
     .target(
@@ -16,6 +19,10 @@ let package = Package(
     .testTarget(
       name: "CasePathsTests",
       dependencies: ["CasePaths"]
+    ),
+    .target(
+      name: "swift-case-paths-benchmark",
+      dependencies: ["CasePaths", "Benchmark"]
     ),
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
+    .package(name: "Benchmark", url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
   ],
   targets: [
     .target(
@@ -25,7 +25,7 @@ let package = Package(
       name: "swift-case-paths-benchmark",
       dependencies: [
         "CasePaths",
-        .product(name: "Benchmark", package: "swift-benchmark"),
+        .product(name: "Benchmark", package: "Benchmark"),
       ]
     ),
   ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,5 @@
 // swift-tools-version:5.2
+
 import PackageDescription
 
 let package = Package(
@@ -10,7 +11,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/google/swift-benchmark", from: "0.1.0")
+    .package(url: "https://github.com/google/swift-benchmark", from: "0.1.0"),
   ],
   targets: [
     .target(

--- a/Package@swift-5.1.swift
+++ b/Package@swift-5.1.swift
@@ -1,4 +1,5 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.1
+
 import PackageDescription
 
 let package = Package(
@@ -9,9 +10,6 @@ let package = Package(
       targets: ["CasePaths"]
     ),
   ],
-  dependencies: [
-    .package(url: "https://github.com/google/swift-benchmark", from: "0.1.0")
-  ],
   targets: [
     .target(
       name: "CasePaths"
@@ -19,13 +17,6 @@ let package = Package(
     .testTarget(
       name: "CasePathsTests",
       dependencies: ["CasePaths"]
-    ),
-    .target(
-      name: "swift-case-paths-benchmark",
-      dependencies: [
-        "CasePaths",
-        .product(name: "Benchmark", package: "swift-benchmark"),
-      ]
     ),
   ]
 )

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -69,12 +69,8 @@ public func extract<Root, Value>(_ embed: @escaping (Value) -> Root) -> (Root) -
   return { root in
     guard let rootTag = enumTag(root) else { return nil }
     if let cachedTag = cachedTag, cachedTag != rootTag { return nil }
-    let mirror = Mirror(reflecting: root)
-    assert(mirror.displayStyle == .enum || mirror.displayStyle == .optional)
-    guard
-      let child = mirror.children.first,
-      case let childMirror = Mirror(reflecting: child.value),
-      let value = child.value as? Value ?? childMirror.children.first?.value as? Value
+    guard let value = (Mirror(reflecting: root).children.first?.value)
+      .flatMap({ $0 as? Value ?? Mirror(reflecting: $0).children.first?.value as? Value })
     else {
       #if compiler(<5.2)
         // https://bugs.swift.org/browse/SR-12044

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -10,7 +10,7 @@ extension CasePath {
   public static func `case`(_ embed: @escaping (Value) -> Root) -> CasePath {
     return self.init(
       embed: embed,
-      extract: { CasePaths.extract(case: embed, from: $0) }
+      extract: CasePaths.extract(embed)
     )
   }
 }
@@ -46,32 +46,8 @@ extension CasePath where Value == Void {
 ///   - root: A root enum value.
 /// - Returns: Values iff they can be extracted from the given enum case initializer and root enum,
 ///   otherwise `nil`.
-public func extract<Root, Value>(case embed: (Value) -> Root, from root: Root) -> Value? {
-  func extractHelp(from root: Root) -> ([String?], Value)? {
-    let mirror = Mirror(reflecting: root)
-    assert(mirror.displayStyle == .enum || mirror.displayStyle == .optional)
-    guard
-      let child = mirror.children.first,
-      let childLabel = child.label,
-      case let childMirror = Mirror(reflecting: child.value),
-      let value = child.value as? Value ?? childMirror.children.first?.value as? Value
-    else {
-      #if compiler(<5.2)
-        // https://bugs.swift.org/browse/SR-12044
-        if MemoryLayout<Value>.size == 0, !isUninhabitedEnum(Value.self) {
-          return (["\(root)"], unsafeBitCast((), to: Value.self))
-        }
-      #endif
-      return nil
-    }
-    return ([childLabel] + childMirror.children.map { $0.label }, value)
-  }
-  guard
-    let (rootPath, value) = extractHelp(from: root),
-    let (embedPath, _) = extractHelp(from: embed(value)),
-    rootPath == embedPath
-  else { return nil }
-  return value
+public func extract<Root, Value>(case embed: @escaping (Value) -> Root, from root: Root) -> Value? {
+  CasePaths.extract(embed)(root)
 }
 
 /// Returns a function that can attempt to extract associated values from the given enum case
@@ -89,8 +65,30 @@ public func extract<Root, Value>(case embed: (Value) -> Root, from root: Root) -
 /// - Parameter embed: An enum case initializer.
 /// - Returns: A function that can attempt to extract associated values from an enum.
 public func extract<Root, Value>(_ embed: @escaping (Value) -> Root) -> (Root) -> (Value?) {
+  var cachedTag: UInt32?
   return { root in
-    return extract(case: `case`, from: root)
+    guard let rootTag = enumTag(root) else { return nil }
+    if let cachedTag = cachedTag, cachedTag != rootTag { return nil }
+    let mirror = Mirror(reflecting: root)
+    assert(mirror.displayStyle == .enum || mirror.displayStyle == .optional)
+    guard
+      let child = mirror.children.first,
+      case let childMirror = Mirror(reflecting: child.value),
+      let value = child.value as? Value ?? childMirror.children.first?.value as? Value
+    else {
+      #if compiler(<5.2)
+        // https://bugs.swift.org/browse/SR-12044
+        if MemoryLayout<Value>.size == 0, !isUninhabitedEnum(Value.self) {
+          return unsafeBitCast((), to: Value.self)
+        }
+      #endif
+      return nil
+    }
+    if rootTag == cachedTag { return value }
+    guard let embedTag = enumTag(embed(value)) else { return nil }
+    cachedTag = embedTag
+    if rootTag == embedTag { return value }
+    return nil
   }
 }
 
@@ -131,4 +129,22 @@ private func isUninhabitedEnum(_ type: Any.Type) -> Bool {
 
   let numCases = enumTypeDescriptor.numPayloadCases + enumTypeDescriptor.numEmptyCases
   return numCases == 0
+}
+
+private func enumTag<Case>(_ `case`: Case) -> UInt32? {
+  let metadataPtr = unsafeBitCast(type(of: `case`), to: UnsafeRawPointer.self)
+  let kind = metadataPtr.load(as: Int.self)
+  let isEnumOrOptional = kind == 0x201 || kind == 0x202
+  guard isEnumOrOptional else { return nil }
+  let vwtPtr = (metadataPtr - MemoryLayout<UnsafeRawPointer>.size).load(as: UnsafeRawPointer.self)
+  let vwt = vwtPtr.load(as: EnumValueWitnessTable.self)
+  return withUnsafePointer(to: `case`) { vwt.getEnumTag($0, metadataPtr) }
+}
+
+private struct EnumValueWitnessTable {
+  let f1, f2, f3, f4, f5, f6, f7, f8: UnsafeRawPointer
+  let f9, f10: Int
+  let f11, f12: UInt32
+  let getEnumTag: @convention(c) (UnsafeRawPointer, UnsafeRawPointer) -> UInt32
+  let f13, f14: UnsafeRawPointer
 }

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -57,6 +57,7 @@ public func extract<Root, Value>(case embed: (Value) -> Root, from root: Root) -
       let value = child.value as? Value ?? childMirror.children.first?.value as? Value
     else {
       #if compiler(<5.2)
+        // https://bugs.swift.org/browse/SR-12044
         if MemoryLayout<Value>.size == 0, !isUninhabitedEnum(Value.self) {
           return (["\(root)"], unsafeBitCast((), to: Value.self))
         }

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -86,9 +86,9 @@ public func extract<Root, Value>(case embed: (Value) -> Root, from root: Root) -
 ///
 /// - Note: This function is only intended to be used with enum case initializers. Its behavior is
 ///   otherwise undefined.
-/// - Parameter case: An enum case initializer.
+/// - Parameter embed: An enum case initializer.
 /// - Returns: A function that can attempt to extract associated values from an enum.
-public func extract<Root, Value>(_ case: @escaping (Value) -> Root) -> (Root) -> (Value?) {
+public func extract<Root, Value>(_ embed: @escaping (Value) -> Root) -> (Root) -> (Value?) {
   return { root in
     return extract(case: `case`, from: root)
   }

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -56,7 +56,7 @@ public func extract<Root, Value>(case embed: (Value) -> Root, from root: Root) -
       case let childMirror = Mirror(reflecting: child.value),
       let value = child.value as? Value ?? childMirror.children.first?.value as? Value
     else { return nil }
-    return ([childLabel] + childMirror.children.map(\.label), value)
+    return ([childLabel] + childMirror.children.map { $0.label }, value)
   }
   guard
     let (rootPath, value) = dump(extractHelp(from: root)),

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -67,8 +67,8 @@ public func extract<Root, Value>(case embed: (Value) -> Root, from root: Root) -
     return ([childLabel] + childMirror.children.map { $0.label }, value)
   }
   guard
-    let (rootPath, value) = dump(extractHelp(from: root)),
-    let (embedPath, _) = dump(extractHelp(from: embed(value))),
+    let (rootPath, value) = extractHelp(from: root),
+    let (embedPath, _) = extractHelp(from: embed(value)),
     rootPath == embedPath
   else { return nil }
   return value

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -55,7 +55,14 @@ public func extract<Root, Value>(case embed: (Value) -> Root, from root: Root) -
       let childLabel = child.label,
       case let childMirror = Mirror(reflecting: child.value),
       let value = child.value as? Value ?? childMirror.children.first?.value as? Value
-    else { return nil }
+    else {
+      #if compiler(<5.2)
+        if MemoryLayout<Value>.size == 0, !isUninhabitedEnum(Value.self) {
+          return (["\(root)"], unsafeBitCast((), to: Value.self))
+        }
+      #endif
+      return nil
+    }
     return ([childLabel] + childMirror.children.map { $0.label }, value)
   }
   guard

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -1,5 +1,3 @@
-import func Foundation.memcmp
-
 extension CasePath {
   /// Returns a case path that extracts values associated with a given enum case initializer.
   ///

--- a/Sources/swift-case-paths-benchmark/main.swift
+++ b/Sources/swift-case-paths-benchmark/main.swift
@@ -40,5 +40,5 @@ let failure = BenchmarkSuite(name: "Failure") {
 
 Benchmark.main([
   success,
-  failure
+  failure,
 ])

--- a/Sources/swift-case-paths-benchmark/main.swift
+++ b/Sources/swift-case-paths-benchmark/main.swift
@@ -1,0 +1,44 @@
+import Benchmark
+import CasePaths
+
+enum Enum {
+  case associatedValue(Int)
+  case anotherAssociatedValue(String)
+}
+
+let enumCase = Enum.associatedValue(42)
+let anotherCase = Enum.anotherAssociatedValue("Blob")
+
+let manual = CasePath(
+  embed: Enum.associatedValue,
+  extract: {
+    guard case let .associatedValue(value) = $0 else { return nil }
+    return value
+  }
+)
+let reflection: CasePath<Enum, Int> = /Enum.associatedValue
+
+let success = BenchmarkSuite(name: "Success") {
+  $0.benchmark("Manual") {
+    precondition(manual.extract(from: enumCase) == 42)
+  }
+
+  $0.benchmark("Reflection") {
+    precondition(reflection.extract(from: enumCase) == 42)
+  }
+}
+
+let failure = BenchmarkSuite(name: "Failure") {
+  $0.benchmark("Manual") {
+    precondition(manual.extract(from: anotherCase) == nil)
+  }
+
+  $0.benchmark("Reflection") {
+    precondition(reflection.extract(from: anotherCase) == nil)
+  }
+}
+
+Benchmark.main([
+  success,
+  failure
+])

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -68,12 +68,6 @@ final class CasePathsTests: XCTestCase {
       (/.self)
         .extract(from: 42)
     )
-
-    XCTAssertEqual(
-      .some(42),
-      (/{ $0 })
-        .extract(from: 42)
-    )
   }
 
   func testLabeledCases() {
@@ -90,18 +84,6 @@ final class CasePathsTests: XCTestCase {
     XCTAssertNil(
       (/Foo.bar(some:))
         .extract(from: .bar(none: 42))
-    )
-
-    XCTAssertEqual(
-      .some(42),
-      //      (/Foo.bar(none:)) // Abort trap: 6
-      CasePath.case { Foo.bar(none: $0) }
-        .extract(from: .bar(none: 42))
-    )
-    XCTAssertNil(
-      //      (/Foo.bar(none:)) // Abort trap: 6
-      CasePath.case { Foo.bar(none: $0) }
-        .extract(from: .bar(some: 42))
     )
   }
 
@@ -137,17 +119,6 @@ final class CasePathsTests: XCTestCase {
     XCTAssertEqual("Blob", fizzBuzz.buzz)
   }
 
-  func testSingleValueExtractionFromMultiple() {
-    enum Foo {
-      case bar(fizz: Int, buzz: String)
-    }
-
-    XCTAssertEqual(
-      .some(42),
-      extract(case: { Foo.bar(fizz: $0, buzz: "Blob") }, from: .bar(fizz: 42, buzz: "Blob"))
-    )
-  }
-
   func testMultiMixedCases() {
     enum Foo {
       case bar(Int, buzz: String)
@@ -162,20 +133,6 @@ final class CasePathsTests: XCTestCase {
     }
     XCTAssertEqual(42, fizzBuzz.0)
     XCTAssertEqual("Blob", fizzBuzz.1)
-  }
-
-  func testNestedReflection() {
-    enum Foo {
-      case bar(Bar)
-    }
-    enum Bar {
-      case baz(Int)
-    }
-
-    XCTAssertEqual(
-      42,
-      extract(case: { Foo.bar(.baz($0)) }, from: .bar(.baz(42)))
-    )
   }
 
   func testNestedZeroMemoryLayout() {
@@ -236,20 +193,6 @@ final class CasePathsTests: XCTestCase {
       (/Foo.baz)
         .extract(from: .bar)
     )
-
-    XCTAssertNotNil(
-      extract(case: { Foo.bar }, from: .bar)
-    )
-    XCTAssertNil(
-      extract(case: { Foo.bar }, from: .baz)
-    )
-
-    XCTAssertNotNil(
-      extract(case: { Foo.baz }, from: .baz)
-    )
-    XCTAssertNil(
-      extract(case: { Foo.baz }, from: .bar)
-    )
   }
 
   func testEnumsWithClosures() {
@@ -277,10 +220,10 @@ final class CasePathsTests: XCTestCase {
 
     XCTAssertEqual(
       .some(42),
-      extract(case: { Foo.foo(.foo(.foo(.bar($0)))) }, from: .foo(.foo(.foo(.bar(42)))))
+      (/Foo.foo .. /Foo.foo .. /Foo.foo .. /Foo.bar).extract(from: .foo(.foo(.foo(.bar(42)))))
     )
     XCTAssertNil(
-      extract(case: { Foo.foo(.foo(.foo(.bar($0)))) }, from: .foo(.foo(.bar(42))))
+      (/Foo.foo .. /Foo.foo .. /Foo.foo .. /Foo.bar).extract(from: .foo(.foo(.bar(42))))
     )
   }
 
@@ -384,27 +327,4 @@ final class CasePathsTests: XCTestCase {
       XCTFail()
     }
   }
-
-  //  func testStructs() {
-  //    struct Point { var x: Double, y: Double }
-  //
-  //    guard
-  //      let (x, y) = CasePath(Point.init(x:y:))
-  //        .extract(from: Point(x: 16, y: 8))
-  //      else {
-  //        XCTFail()
-  //        return
-  //    }
-  //
-  //    XCTAssertEqual(16, x)
-  //    XCTAssertEqual(8, y)
-  //
-  //    guard
-  //      let (x1, y2) = CasePath(Point.init(what:where:))
-  //        .extract(from: Point(x: 16, y: 8))
-  //      else {
-  //        XCTFail()
-  //        return
-  //    }
-  //  }
 }


### PR DESCRIPTION
This code speeds up reflective case paths in a couple ways:

- We were previously constructing the "identity" of a case path's case by accumulating labels off a value's mirror, but we recently found some runtime metadata APIs that can compute the "tag" of an enum much more efficiently, so we can lean on that instead.
- Computing the enum tag can be done before we reflect on a value, so we can avoid that more intense work so long as we have previously successfully extracted a value from the case path. Upon the first successful extraction we can cache the case path's tag and use it to bail out early when future extractions don't match.

This PR also includes benchmarks that could be helpful when we make changes/improvements in the future.