### PR TITLE
use destructiveProjectEnumData value witness function

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/CasePaths.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/CasePaths.xcscheme
@@ -27,6 +27,13 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <AdditionalOptions>
+         <AdditionalOption
+            key = "MallocStackLogging"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+      </AdditionalOptions>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/.swiftpm/xcode/xcshareddata/xcschemes/CasePaths.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/CasePaths.xcscheme
@@ -26,14 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
-      <AdditionalOptions>
-         <AdditionalOption
-            key = "MallocStackLogging"
-            value = ""
-            isEnabled = "YES">
-         </AdditionalOption>
-      </AdditionalOptions>
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/.swiftpm/xcode/xcshareddata/xcschemes/swift-case-paths-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/swift-case-paths-Package.xcscheme
@@ -48,6 +48,20 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CCasePaths"
+               BuildableName = "CCasePaths"
+               BlueprintName = "CCasePaths"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/Package.swift
+++ b/Package.swift
@@ -15,15 +15,15 @@ let package = Package(
   ],
   targets: [
     .target(
-        name: "CCasePaths"
-    ),
-    .target(
       name: "CasePaths",
       dependencies: ["CCasePaths"]
     ),
     .testTarget(
       name: "CasePathsTests",
       dependencies: ["CasePaths"]
+    ),
+    .target(
+      name: "CCasePaths"
     ),
     .target(
       name: "swift-case-paths-benchmark",

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,11 @@ let package = Package(
   ],
   targets: [
     .target(
-      name: "CasePaths"
+        name: "CCasePaths"
+    ),
+    .target(
+      name: "CasePaths",
+      dependencies: ["CCasePaths"]
     ),
     .testTarget(
       name: "CasePathsTests",

--- a/Package@swift-5.1.swift
+++ b/Package@swift-5.1.swift
@@ -12,11 +12,15 @@ let package = Package(
   ],
   targets: [
     .target(
-      name: "CasePaths"
+      name: "CasePaths",
+      dependencies: ["CCasePaths"]
     ),
     .testTarget(
       name: "CasePathsTests",
       dependencies: ["CasePaths"]
+    ),
+    .target(
+      name: "CCasePaths"
     ),
   ]
 )

--- a/Sources/CCasePaths/Builtin_NativeObject_metadata.c
+++ b/Sources/CCasePaths/Builtin_NativeObject_metadata.c
@@ -1,0 +1,8 @@
+#include "Builtin_NativeObject_metadata.h"
+
+// This is the mangled name of Builtin.NativeObject's metadata.
+extern void $sBoN;
+
+void const *__nonnull getBuiltinNativeObjectFullMetadata() {
+    return &$sBoN;
+}

--- a/Sources/CCasePaths/Builtin_NativeObject_metadata.c
+++ b/Sources/CCasePaths/Builtin_NativeObject_metadata.c
@@ -3,6 +3,6 @@
 // This is the mangled name of Builtin.NativeObject's metadata.
 extern void $sBoN;
 
-void const *__nonnull getBuiltinNativeObjectFullMetadata() {
+void const *getBuiltinNativeObjectFullMetadata() {
     return &$sBoN;
 }

--- a/Sources/CCasePaths/include/Builtin_NativeObject_metadata.h
+++ b/Sources/CCasePaths/include/Builtin_NativeObject_metadata.h
@@ -2,6 +2,8 @@
 #define Builtin_NativeObject_metadata_H
 
 /// Return the address of the “full” metadata for Builtin.NativeObject. A pointer to metadata usually points to the `kind` field of the metadata, which is not the first field of the metadata. The value witness table pointer precedes the `kind` field.
-void const *__nonnull getBuiltinNativeObjectFullMetadata();
+///
+/// Ideally this would be declared `__nonnull`, but the Linux compiler doesn't like that.
+void const *getBuiltinNativeObjectFullMetadata();
 
 #endif /* Builtin_NativeObject_metadata_H */

--- a/Sources/CCasePaths/include/Builtin_NativeObject_metadata.h
+++ b/Sources/CCasePaths/include/Builtin_NativeObject_metadata.h
@@ -1,0 +1,7 @@
+#ifndef Builtin_NativeObject_metadata_H
+#define Builtin_NativeObject_metadata_H
+
+/// Return the address of the “full” metadata for Builtin.NativeObject. A pointer to metadata usually points to the `kind` field of the metadata, which is not the first field of the metadata. The value witness table pointer precedes the `kind` field.
+void const *__nonnull getBuiltinNativeObjectFullMetadata();
+
+#endif /* Builtin_NativeObject_metadata_H */

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -73,7 +73,7 @@ public func extract<Root, Value>(_ embed: @escaping (Value) -> Root) -> (Root) -
 
     if let cachedTag = cachedTag {
       guard cachedTag == rootTag else { return nil }
-      return associatedValues(of: root)
+      return .some(associatedValues(of: root))
     }
 
     guard

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -146,7 +146,6 @@ private func associatedValues<Enum, Values>(of `enum`: Enum) -> Values {
   enumPtr.initialize(to: `enum`)
   let untypedPtr = UnsafeMutableRawPointer(enumPtr)
   vwt.destructiveProjectEnumData(untypedPtr, metadataPtr)
-  // Maybe this should be .bindMemory instead of .assumingMemoryBound?
   let valuesPtr = untypedPtr.assumingMemoryBound(to: Values.self)
   defer {
     valuesPtr.deinitialize(count: 1)

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -288,7 +288,7 @@ private struct EnumMetadata: Metadata {
 @_silgen_name("swift_allocBox")
 private func swift_allocBox(for metadata: UnsafeRawPointer) -> BoxPair
 
-@_silgen_name("swift_allocBox")
+@_silgen_name("swift_deallocBox")
 private func swift_deallocBox(_ heapObject: UnsafeMutableRawPointer)
 
 @_silgen_name("swift_projectBox")

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -324,7 +324,6 @@ private struct FieldDescriptor {
   /// The size of a FieldRecord as stored in the executable.
   var recordSize: Int { Int(ptr.advanced(by: 2 * 4 + 2).load(as: UInt16.self)) }
 
-  var fieldCount: UInt32 { ptr.advanced(by: 2 * 4 + 2 * 2).load(as: UInt32.self) }
 
   func field(atIndex i: UInt32) -> FieldRecord {
     return FieldRecord(

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -100,7 +100,6 @@ public func extract<Root, Value>(_ embed: @escaping (Value) -> Root) -> (Root) -
       #endif
       return nil
     }
-    if rootTag == cachedTag { return value }
     let embedTag = metadata.tag(of: embed(value))
     cachedTag = embedTag
     if rootTag == embedTag { return value }

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -249,7 +249,7 @@ private struct EnumMetadata: Metadata {
 
       // Note that this getter returns the pointer to the “full” metadata, which must be advanced by a word to become a normal metadata pointer.
       let boxType = NativeObjectMetadata(
-        ptr: getBuiltinNativeObjectFullMetadata().advanced(by: pointerSize))
+        ptr: getBuiltinNativeObjectFullMetadata()!.advanced(by: pointerSize))
       let pair = swift_allocBox(for: boxType.ptr)
       boxType.initialize(pair.buffer, byTaking: enumCopyContainer)
       deallocateBoxForExistential(in: enumCopy)

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -76,11 +76,10 @@ public func extract<Root, Value>(_ embed: @escaping (Value) -> Root) -> (Root) -
 
     if let cachedTag = cachedTag {
       guard cachedTag == rootTag else { return nil }
-      if metadata.typeDescriptor.fieldDescriptor.field(atIndex: rootTag).isIndirectCase {
-        return .some(metadata.indirectAssociatedValue(of: root, as: Value.self))
-      } else {
-        return .some(metadata.directAssociatedValue(of: root, as: Value.self))
-      }
+      return .some(
+        metadata.typeDescriptor.fieldDescriptor.field(atIndex: rootTag).isIndirectCase
+          ? metadata.indirectAssociatedValue(of: root, as: Value.self)
+          : metadata.directAssociatedValue(of: root, as: Value.self))
     }
 
     guard

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -183,11 +183,6 @@ extension Metadata {
 
   var kind: MetadataKind { ptr.load(as: MetadataKind.self) }
 
-  var typeDescriptor: EnumTypeDescriptor {
-    return EnumTypeDescriptor(
-      ptr: ptr.advanced(by: pointerSize).load(as: UnsafeRawPointer.self))
-  }
-
   func initialize(_ dest: UnsafeMutableRawPointer, byCopying source: UnsafeMutableRawPointer) {
     _ = valueWitnessTable.initializeWithCopy(dest, source, ptr)
   }
@@ -207,6 +202,11 @@ private struct EnumMetadata: Metadata {
   init?(_ type: Any.Type) {
     ptr = unsafeBitCast(type, to: UnsafeRawPointer.self)
     guard kind == .enumeration || kind == .optional else { return nil }
+  }
+
+  var typeDescriptor: EnumTypeDescriptor {
+    return EnumTypeDescriptor(
+      ptr: ptr.advanced(by: pointerSize).load(as: UnsafeRawPointer.self))
   }
 
   func tag<Enum>(of value: Enum) -> UInt32 {
@@ -305,6 +305,7 @@ private struct EnumTypeDescriptor {
       ptr: ptr.advanced(by: 4 * 4).loadRelativePointer())
   }
 
+  #if compiler(<5.2)
   var numPayloadCases: Int32 {
     return ptr.advanced(by: 5 * 4).load(as: Int32.self) & 0xFFFFFF
   }
@@ -314,6 +315,7 @@ private struct EnumTypeDescriptor {
   }
 
   var isInhabited: Bool { numPayloadCases + numEmptyCases > 0 }
+  #endif
 }
 
 private struct FieldDescriptor {

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -153,31 +153,39 @@ final class CasePathsTests: XCTestCase {
     }
   }
 
+  fileprivate class Object: Equatable {
+    static func == (lhs: Object, rhs: Object) -> Bool {
+      return lhs === rhs
+    }
+  }
+
   func testIndirectCompoundPayload() throws {
+    let object = Object()
+
     enum Enum: Equatable {
-      indirect case indirect(Int, NSObject?, Int, NSObject?)
-      case direct(Int, NSObject?, Int, NSObject?)
+      indirect case indirect(Int, Object?, Int, Object?)
+      case direct(Int, Object?, Int, Object?)
     }
 
-    let indirectPath: CasePath<Enum, (Int, NSObject?, Int, NSObject?)> = /Enum.indirect
-    let directPath: CasePath<Enum, (Int, NSObject?, Int, NSObject?)> = /Enum.direct
+    let indirectPath: CasePath<Enum, (Int, Object?, Int, Object?)> = /Enum.indirect
+    let directPath: CasePath<Enum, (Int, Object?, Int, Object?)> = /Enum.direct
 
     for _ in 1...2 {
       do {
-        let actual = indirectPath.extract(from: .indirect(42, nil, 43, self))
-        XCTAssert(try XCTUnwrap(actual) == (42, nil, 43, self))
+        let actual = indirectPath.extract(from: .indirect(42, nil, 43, object))
+        XCTAssert(try XCTUnwrap(actual) == (42, nil, 43, object))
       }
       do {
-        let actual = indirectPath.extract(from: .direct(42, nil, 43, self))
+        let actual = indirectPath.extract(from: .direct(42, nil, 43, object))
         XCTAssertNil(actual)
       }
       do {
-        let actual = directPath.extract(from: .indirect(42, nil, 43, self))
+        let actual = directPath.extract(from: .indirect(42, nil, 43, object))
         XCTAssertNil(actual)
       }
       do {
-        let actual = directPath.extract(from: .direct(42, nil, 43, self))
-        XCTAssert(try XCTUnwrap(actual) == (42, nil, 43, self))
+        let actual = directPath.extract(from: .direct(42, nil, 43, object))
+        XCTAssert(try XCTUnwrap(actual) == (42, nil, 43, object))
       }
     }
   }

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -178,6 +178,16 @@ final class CasePathsTests: XCTestCase {
     }
   }
 
+  func testNonEnumExtract() {
+    // This is a bogus CasePath, intended to verify that it just returns nil.
+    let path: CasePath<Int, Int> = /{ $0 }
+
+    for _ in 1...2 {
+      let actual = path.extract(from: 42)
+      XCTAssertNil(actual)
+    }
+  }
+
   func testOptionalPayload() {
     enum Enum { case int(Int?) }
     let path = /Enum.int

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -1,6 +1,13 @@
 import CasePaths
 import XCTest
 
+// Replace this with XCTUnwrap when we drop support for Xcode 11.3.
+fileprivate func unwrap<Wrapped>(_ optional: Wrapped?) throws -> Wrapped {
+  guard let wrapped = optional else { throw UnexpectedNil() }
+  return wrapped
+}
+fileprivate struct UnexpectedNil: Error { }
+
 final class CasePathsTests: XCTestCase {
   func testSimplePayload() {
     enum Enum { case payload(Int) }
@@ -38,7 +45,7 @@ final class CasePathsTests: XCTestCase {
     enum Enum { case payload(Int, String) }
     let path: CasePath<Enum, (Int, String)> = /Enum.payload
     for _ in 1...2 {
-      XCTAssert(try XCTUnwrap(path.extract(from: .payload(42, "Blob"))) == (42, "Blob"))
+      XCTAssert(try unwrap(path.extract(from: .payload(42, "Blob"))) == (42, "Blob"))
     }
   }
 
@@ -47,10 +54,10 @@ final class CasePathsTests: XCTestCase {
     let path: CasePath<Enum, (Int, String)> = /Enum.payload
     for _ in 1...2 {
       XCTAssert(
-        try XCTUnwrap(path.extract(from: .payload(a: 42, b: "Blob"))) == (42, "Blob")
+        try unwrap(path.extract(from: .payload(a: 42, b: "Blob"))) == (42, "Blob")
       )
       XCTAssert(
-        try XCTUnwrap(path.extract(from: .payload(a: 42, b: "Blob"))) == (a: 42, b: "Blob")
+        try unwrap(path.extract(from: .payload(a: 42, b: "Blob"))) == (a: 42, b: "Blob")
       )
     }
   }
@@ -103,7 +110,7 @@ final class CasePathsTests: XCTestCase {
     let path = /Enum.closure
     for _ in 1...2 {
       var invoked = false
-      let closure = try XCTUnwrap(path.extract(from: .closure { invoked = true }))
+      let closure = try unwrap(path.extract(from: .closure { invoked = true }))
       closure()
       XCTAssertTrue(invoked)
     }
@@ -173,7 +180,7 @@ final class CasePathsTests: XCTestCase {
     for _ in 1...2 {
       do {
         let actual = indirectPath.extract(from: .indirect(42, nil, 43, object))
-        XCTAssert(try XCTUnwrap(actual) == (42, nil, 43, object))
+        XCTAssert(try unwrap(actual) == (42, nil, 43, object))
       }
       do {
         let actual = indirectPath.extract(from: .direct(42, nil, 43, object))
@@ -185,7 +192,7 @@ final class CasePathsTests: XCTestCase {
       }
       do {
         let actual = directPath.extract(from: .direct(42, nil, 43, object))
-        XCTAssert(try XCTUnwrap(actual) == (42, nil, 43, object))
+        XCTAssert(try unwrap(actual) == (42, nil, 43, object))
       }
     }
   }
@@ -227,8 +234,8 @@ final class CasePathsTests: XCTestCase {
     let nsObject = NSObject()
     let path = /Enum.anyObject
     for _ in 1...2 {
-      XCTAssert(try XCTUnwrap(path.extract(from: .anyObject(object))) === object)
-      XCTAssert(try XCTUnwrap(path.extract(from: .anyObject(nsObject))) === nsObject)
+      XCTAssert(try unwrap(path.extract(from: .anyObject(object))) === object)
+      XCTAssert(try unwrap(path.extract(from: .anyObject(nsObject))) === nsObject)
     }
   }
 
@@ -251,13 +258,13 @@ final class CasePathsTests: XCTestCase {
     let subclassPath = /Enum.subclass
     for _ in 1...2 {
       XCTAssert(
-        try XCTUnwrap(superclassPath.extract(from: .superclass(superclass))) === superclass
+        try unwrap(superclassPath.extract(from: .superclass(superclass))) === superclass
       )
       XCTAssert(
-        try XCTUnwrap(superclassPath.extract(from: .superclass(subclass))) === subclass
+        try unwrap(superclassPath.extract(from: .superclass(subclass))) === subclass
       )
       XCTAssert(
-        try XCTUnwrap(subclassPath.extract(from: .subclass(subclass))) === subclass
+        try unwrap(subclassPath.extract(from: .subclass(subclass))) === subclass
       )
     }
   }
@@ -267,7 +274,7 @@ final class CasePathsTests: XCTestCase {
     let path: CasePath<Enum, (Int, Int?, String, UInt)> = /Enum.n
     for _ in 1...2 {
       XCTAssert(
-        try XCTUnwrap(path.extract(from: .n(42))) == (42, nil, #file, #line)
+        try unwrap(path.extract(from: .n(42))) == (42, nil, #file, #line)
       )
     }
   }

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -22,8 +22,9 @@ final class CasePathsTests: XCTestCase {
     // This test crashes Xcode 11.7's compiler.
 #else
   func testSimpleOverloadedPayload() {
-    let pathA = /SimpleOverloadedEnum.payload(a:)
-    let pathB = /SimpleOverloadedEnum.payload(b:)
+    enum Enum { case payload(a: Int), payload(b: Int) }
+    let pathA = /Enum.payload(a:)
+    let pathB = /Enum.payload(b:)
     for _ in 1...2 {
       XCTAssertEqual(pathA.extract(from: .payload(a: 42)), 42)
       XCTAssertEqual(pathA.extract(from: .payload(b: 42)), nil)

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -120,6 +120,64 @@ final class CasePathsTests: XCTestCase {
     }
   }
 
+  func testIndirectSimplePayload() {
+    enum Enum: Equatable {
+      indirect case indirect(Int)
+      case direct(Int)
+    }
+
+    let indirectPath = /Enum.indirect
+    let directPath = /Enum.direct
+
+    for _ in 1...2 {
+      do {
+        let actual = indirectPath.extract(from: .indirect(42))
+        XCTAssertEqual(actual, 42)
+      }
+      do {
+        let actual = indirectPath.extract(from: .direct(42))
+        XCTAssertEqual(actual, nil)
+      }
+      do {
+        let actual = directPath.extract(from: .indirect(42))
+        XCTAssertEqual(actual, nil)
+      }
+      do {
+        let actual = directPath.extract(from: .direct(42))
+        XCTAssertEqual(actual, 42)
+      }
+    }
+  }
+
+  func testIndirectCompoundPayload() throws {
+    enum Enum: Equatable {
+      indirect case indirect(Int, NSObject?, Int, NSObject?)
+      case direct(Int, NSObject?, Int, NSObject?)
+    }
+
+    let indirectPath: CasePath<Enum, (Int, NSObject?, Int, NSObject?)> = /Enum.indirect
+    let directPath: CasePath<Enum, (Int, NSObject?, Int, NSObject?)> = /Enum.direct
+
+    for _ in 1...2 {
+      do {
+        let actual = indirectPath.extract(from: .indirect(42, nil, 43, self))
+        XCTAssert(try XCTUnwrap(actual) == (42, nil, 43, self))
+      }
+      do {
+        let actual = indirectPath.extract(from: .direct(42, nil, 43, self))
+        XCTAssertNil(actual)
+      }
+      do {
+        let actual = directPath.extract(from: .indirect(42, nil, 43, self))
+        XCTAssertNil(actual)
+      }
+      do {
+        let actual = directPath.extract(from: .direct(42, nil, 43, self))
+        XCTAssert(try XCTUnwrap(actual) == (42, nil, 43, self))
+      }
+    }
+  }
+
   func testOptionalPayload() {
     enum Enum { case int(Int?) }
     let path = /Enum.int

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -454,12 +454,6 @@ final class CasePathsTests: XCTestCase {
         .compactMap(/Result.success .. Optional.some)
     )
 
-    XCTAssertEqual(
-      [1],
-      [Result.success(1), .success(nil), .failure(MyError())]
-        .compactMap(/{ .success(.some($0)) })
-    )
-
     enum Authentication {
       case authenticated(token: String)
       case unauthenticated

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -18,10 +18,12 @@ final class CasePathsTests: XCTestCase {
     }
   }
 
+#if compiler(<5.3)
+    // This test crashes Xcode 11.7's compiler.
+#else
   func testSimpleOverloadedPayload() {
-    enum Enum { case payload(a: Int), payload(b: Int) }
-    let pathA = /Enum.payload(a:)
-    let pathB = /Enum.payload(b:)
+    let pathA = /SimpleOverloadedEnum.payload(a:)
+    let pathB = /SimpleOverloadedEnum.payload(b:)
     for _ in 1...2 {
       XCTAssertEqual(pathA.extract(from: .payload(a: 42)), 42)
       XCTAssertEqual(pathA.extract(from: .payload(b: 42)), nil)
@@ -29,6 +31,7 @@ final class CasePathsTests: XCTestCase {
       XCTAssertEqual(pathB.extract(from: .payload(b: 42)), 42)
     }
   }
+#endif
 
   func testMultiPayload() {
     enum Enum { case payload(Int, String) }

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -124,8 +124,11 @@ final class CasePathsTests: XCTestCase {
     enum Enum { case int(Int?) }
     let path = /Enum.int
     for _ in 1...2 {
-      XCTAssertEqual(path.extract(from: .int(.some(42))), .some(.some(42)))
-      XCTAssertEqual(path.extract(from: .int(.none)), .some(.none))
+      let actual1 = path.extract(from: .int(.some(42)))
+      XCTAssertEqual(actual1, .some(.some(42)))
+
+      let actual2 = path.extract(from: .int(.none))
+      XCTAssertEqual(actual2, .some(.none))
     }
   }
 

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -2,6 +2,231 @@ import CasePaths
 import XCTest
 
 final class CasePathsTests: XCTestCase {
+  func testSimplePayload() {
+    enum Enum { case payload(Int) }
+    let path = /Enum.payload
+    for _ in 1...2 {
+      XCTAssertEqual(path.extract(from: .payload(42)), 42)
+    }
+  }
+
+  func testSimpleLabeledPayload() {
+    enum Enum { case payload(label: Int) }
+    let path = /Enum.payload(label:)
+    for _ in 1...2 {
+      XCTAssertEqual(path.extract(from: .payload(label: 42)), 42)
+    }
+  }
+
+  func testSimpleOverloadedPayload() {
+    enum Enum { case payload(a: Int), payload(b: Int) }
+    let pathA = /Enum.payload(a:)
+    let pathB = /Enum.payload(b:)
+    for _ in 1...2 {
+      XCTAssertEqual(pathA.extract(from: .payload(a: 42)), 42)
+      XCTAssertEqual(pathA.extract(from: .payload(b: 42)), nil)
+      XCTAssertEqual(pathB.extract(from: .payload(a: 42)), nil)
+      XCTAssertEqual(pathB.extract(from: .payload(b: 42)), 42)
+    }
+  }
+
+  func testMultiPayload() {
+    enum Enum { case payload(Int, String) }
+    let path: CasePath<Enum, (Int, String)> = /Enum.payload
+    for _ in 1...2 {
+      XCTAssert(try XCTUnwrap(path.extract(from: .payload(42, "Blob"))) == (42, "Blob"))
+    }
+  }
+
+  func testMultiLabeledPayload() {
+    enum Enum { case payload(a: Int, b: String) }
+    let path: CasePath<Enum, (Int, String)> = /Enum.payload
+    for _ in 1...2 {
+      XCTAssert(
+        try XCTUnwrap(path.extract(from: .payload(a: 42, b: "Blob"))) == (42, "Blob")
+      )
+      XCTAssert(
+        try XCTUnwrap(path.extract(from: .payload(a: 42, b: "Blob"))) == (a: 42, b: "Blob")
+      )
+    }
+  }
+
+  func testNoPayload() {
+    enum Enum { case a, b }
+    let pathA = /Enum.a
+    let pathB = /Enum.b
+    for _ in 1...2 {
+      XCTAssertNotNil(pathA.extract(from: .a))
+      XCTAssertNotNil(pathB.extract(from: .b))
+      XCTAssertNil(pathA.extract(from: .b))
+      XCTAssertNil(pathB.extract(from: .a))
+    }
+  }
+
+  func testZeroMemoryLayoutPayload() {
+    struct Unit1 {}
+    enum Unit2 { case unit }
+    enum Enum { case void(Void), unit1(Unit1), unit2(Unit2) }
+    let path1 = /Enum.void
+    let path2 = /Enum.unit1
+    let path3 = /Enum.unit2
+    for _ in 1...2 {
+      XCTAssertNotNil(path1.extract(from: .void(())))
+      XCTAssertNotNil(path2.extract(from: .unit1(.init())))
+      XCTAssertNotNil(path3.extract(from: .unit2(.unit)))
+      XCTAssertNil(path1.extract(from: .unit1(.init())))
+      XCTAssertNil(path1.extract(from: .unit2(.unit)))
+      XCTAssertNil(path2.extract(from: .void(())))
+      XCTAssertNil(path2.extract(from: .unit2(.unit)))
+      XCTAssertNil(path3.extract(from: .void(())))
+      XCTAssertNil(path3.extract(from: .unit1(.init())))
+    }
+  }
+
+  func testUninhabitedPayload() {
+    enum Uninhabited {}
+    enum Enum { case never(Never), uninhabited(Uninhabited), value }
+    let path1 = /Enum.never
+    let path2 = /Enum.uninhabited
+    for _ in 1...2 {
+      XCTAssertNil(path1.extract(from: .value))
+      XCTAssertNil(path2.extract(from: .value))
+    }
+  }
+
+  func testClosurePayload() throws {
+    enum Enum { case closure(() -> Void) }
+    let path = /Enum.closure
+    for _ in 1...2 {
+      var invoked = false
+      let closure = try XCTUnwrap(path.extract(from: .closure { invoked = true }))
+      closure()
+      XCTAssertTrue(invoked)
+    }
+  }
+
+  func testRecursivePayload() {
+    indirect enum Enum: Equatable {
+      case indirect(Enum)
+      case direct
+    }
+    let shallowPath = /Enum.indirect
+    let deepPath = /Enum.indirect
+    for _ in 1...2 {
+      XCTAssertEqual(shallowPath.extract(from: .indirect(.direct)), .direct)
+      XCTAssertEqual(
+        deepPath.extract(from: .indirect(.indirect(.direct))), .indirect(.direct)
+      )
+    }
+  }
+
+  func testOptionalPayload() {
+    enum Enum { case int(Int?) }
+    let path = /Enum.int
+    for _ in 1...2 {
+      XCTAssertEqual(path.extract(from: .int(.some(42))), .some(.some(42)))
+      XCTAssertEqual(path.extract(from: .int(.none)), .some(.none))
+    }
+  }
+
+  func testAnyPayload() {
+    enum Enum { case any(Any) }
+    let path = /Enum.any
+    for _ in 1...2 {
+      XCTAssertEqual(path.extract(from: .any(42)) as? Int, 42)
+    }
+  }
+
+  func testAnyObjectPayload() {
+    class Class {}
+    enum Enum { case anyObject(AnyObject) }
+    let object = Class()
+    let nsObject = NSObject()
+    let path = /Enum.anyObject
+    for _ in 1...2 {
+      XCTAssert(try XCTUnwrap(path.extract(from: .anyObject(object))) === object)
+      XCTAssert(try XCTUnwrap(path.extract(from: .anyObject(nsObject))) === nsObject)
+    }
+  }
+
+  func testProtocolPayload() {
+    struct Error: Swift.Error, Equatable {}
+    enum Enum { case error(Swift.Error) }
+    let path = /Enum.error
+    for _ in 1...2 {
+      XCTAssertEqual(path.extract(from: .error(Error())) as? Error, Error())
+    }
+  }
+
+  func testSubclassPayload() {
+    class Superclass {}
+    class Subclass: Superclass {}
+    enum Enum { case superclass(Superclass), subclass(Subclass) }
+    let superclass = Superclass()
+    let subclass = Subclass()
+    let superclassPath = /Enum.superclass
+    let subclassPath = /Enum.subclass
+    for _ in 1...2 {
+      XCTAssert(
+        try XCTUnwrap(superclassPath.extract(from: .superclass(superclass))) === superclass
+      )
+      XCTAssert(
+        try XCTUnwrap(superclassPath.extract(from: .superclass(subclass))) === subclass
+      )
+      XCTAssert(
+        try XCTUnwrap(subclassPath.extract(from: .subclass(subclass))) === subclass
+      )
+    }
+  }
+
+  func testDefaults() {
+    enum Enum { case n(Int, m: Int? = nil, file: String = #file, line: UInt = #line) }
+    let path: CasePath<Enum, (Int, Int?, String, UInt)> = /Enum.n
+    for _ in 1...2 {
+      XCTAssert(
+        try XCTUnwrap(path.extract(from: .n(42))) == (42, nil, #file, #line)
+      )
+    }
+  }
+
+  func testDifferentMemoryLayouts() {
+    struct Struct { var array: [Int] = [1, 2, 3], string: String = "Blob" }
+    enum Enum { case bool(Bool), int(Int), void(Void), structure(Struct), any(Any) }
+
+    let boolPath = /Enum.bool
+    let intPath = /Enum.int
+    let voidPath = /Enum.void
+    let structPath = /Enum.structure
+    let anyPath = /Enum.any
+    for _ in 1...2 {
+      XCTAssertNil(boolPath.extract(from: .int(42)))
+      XCTAssertNil(boolPath.extract(from: .void(())))
+      XCTAssertNil(boolPath.extract(from: .structure(.init())))
+      XCTAssertNil(boolPath.extract(from: .any("Blob")))
+      XCTAssertNil(intPath.extract(from: .bool(true)))
+      XCTAssertNil(intPath.extract(from: .void(())))
+      XCTAssertNil(intPath.extract(from: .structure(.init())))
+      XCTAssertNil(intPath.extract(from: .any("Blob")))
+      XCTAssertNil(voidPath.extract(from: .bool(true)))
+      XCTAssertNil(voidPath.extract(from: .int(42)))
+      XCTAssertNil(voidPath.extract(from: .structure(.init())))
+      XCTAssertNil(voidPath.extract(from: .any("Blob")))
+      XCTAssertNil(structPath.extract(from: .bool(true)))
+      XCTAssertNil(structPath.extract(from: .int(42)))
+      XCTAssertNil(structPath.extract(from: .void(())))
+      XCTAssertNil(structPath.extract(from: .any("Blob")))
+      XCTAssertNil(anyPath.extract(from: .bool(true)))
+      XCTAssertNil(anyPath.extract(from: .int(42)))
+      XCTAssertNil(anyPath.extract(from: .void(())))
+      XCTAssertNil(anyPath.extract(from: .structure(.init())))
+
+      XCTAssertNotNil(boolPath.extract(from: .bool(true)))
+      XCTAssertNotNil(intPath.extract(from: .int(42)))
+      XCTAssertNotNil(voidPath.extract(from: .void(())))
+      XCTAssertNotNil(anyPath.extract(from: .any("Blob")))
+    }
+  }
+
   func testEmbed() {
     enum Foo: Equatable { case bar(Int) }
 


### PR DESCRIPTION
The destructiveProjectEnumData function in the enum value witness table
transforms an enum value into its associated values in place, by zeroing
out any enum tag bits stored in the payload area of the value.

We can use this function after verifying that the tag of the enum
value is the expected tag. This means we still have to use the
Mirror-and-embed strategy until we can cache the expected tag.

Performance without this commit, on my iMac Pro:

```
name               time        std        iterations
----------------------------------------------------
Success.Manual       34.000 ns ± 232.27 %    1000000
Success.Reflection 3095.000 ns ±  22.64 %     470183
Failure.Manual       36.000 ns ± 167.71 %    1000000
Failure.Reflection   83.000 ns ± 152.31 %    1000000
```

Performance with this commit:

```
name               time       std        iterations
---------------------------------------------------
Success.Manual      35.000 ns ± 158.00 %    1000000
Success.Reflection 167.000 ns ±  70.60 %    1000000
Failure.Manual      37.000 ns ± 197.47 %    1000000
Failure.Reflection  82.000 ns ± 135.63 %    1000000
```
