### PR TITLE
eliminate the use of Mirror

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/CasePaths.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/CasePaths.xcscheme
@@ -27,6 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      disableMainThreadChecker = "YES"
       codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference

--- a/.swiftpm/xcode/xcshareddata/xcschemes/swift-case-paths-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/swift-case-paths-Package.xcscheme
@@ -48,20 +48,6 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CCasePaths"
-               BuildableName = "CCasePaths"
-               BlueprintName = "CCasePaths"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/.swiftpm/xcode/xcshareddata/xcschemes/swift-case-paths-benchmark.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/swift-case-paths-benchmark.xcscheme
@@ -40,8 +40,22 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      disableMainThreadChecker = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES"
+            testExecutionOrdering = "random">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CasePathsTests"
+               BuildableName = "CasePathsTests"
+               BlueprintName = "CasePathsTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Package.swift
+++ b/Package.swift
@@ -15,15 +15,11 @@ let package = Package(
   ],
   targets: [
     .target(
-      name: "CasePaths",
-      dependencies: ["CCasePaths"]
+      name: "CasePaths"
     ),
     .testTarget(
       name: "CasePathsTests",
       dependencies: ["CasePaths"]
-    ),
-    .target(
-      name: "CCasePaths"
     ),
     .target(
       name: "swift-case-paths-benchmark",

--- a/Package@swift-5.1.swift
+++ b/Package@swift-5.1.swift
@@ -12,15 +12,11 @@ let package = Package(
   ],
   targets: [
     .target(
-      name: "CasePaths",
-      dependencies: ["CCasePaths"]
+      name: "CasePaths"
     ),
     .testTarget(
       name: "CasePathsTests",
       dependencies: ["CasePaths"]
-    ),
-    .target(
-      name: "CCasePaths"
     ),
   ]
 )

--- a/Sources/CCasePaths/Builtin_NativeObject_metadata.c
+++ b/Sources/CCasePaths/Builtin_NativeObject_metadata.c
@@ -1,8 +1,0 @@
-#include "Builtin_NativeObject_metadata.h"
-
-// This is the mangled name of Builtin.NativeObject's metadata.
-extern void $sBoN;
-
-void const *getBuiltinNativeObjectFullMetadata() {
-    return &$sBoN;
-}

--- a/Sources/CCasePaths/include/Builtin_NativeObject_metadata.h
+++ b/Sources/CCasePaths/include/Builtin_NativeObject_metadata.h
@@ -1,9 +1,0 @@
-#ifndef Builtin_NativeObject_metadata_H
-#define Builtin_NativeObject_metadata_H
-
-/// Return the address of the “full” metadata for Builtin.NativeObject. A pointer to metadata usually points to the `kind` field of the metadata, which is not the first field of the metadata. The value witness table pointer precedes the `kind` field.
-///
-/// Ideally this would be declared `__nonnull`, but the Linux compiler doesn't like that.
-void const *getBuiltinNativeObjectFullMetadata();
-
-#endif /* Builtin_NativeObject_metadata_H */

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -1,4 +1,3 @@
-import CCasePaths
 
 extension CasePath {
   /// Returns a case path that extracts values associated with a given enum case initializer.
@@ -91,10 +90,8 @@ public func extract<Root, Value>(_ embed: @escaping (Value) -> Root) -> (Root) -
 
     let metadata = EnumMetadata(assumingEnum: Root.self)
 
-    #if true
-
     guard
-      let rootExtractor = Extractor<Root, Value>(root: root),
+      let rootExtractor = Extractor<Root, Value>(tag: metadata.tag(of: root)),
       let value = rootExtractor.extract(from: root)
     else {
       return nil
@@ -109,23 +106,6 @@ public func extract<Root, Value>(_ embed: @escaping (Value) -> Root) -> (Root) -
 
     cachedExtractor = rootExtractor
     return value
-
-    #else
-
-    guard
-      let value = (Mirror(reflecting: root).children.first?.value)
-        .flatMap({ $0 as? Value ?? Mirror(reflecting: $0).children.first?.value as? Value })
-        ?? workaroundForSR12044(Value.self)
-    else {
-      return nil
-    }
-
-    let embedTag = metadata.tag(of: embed(value))
-    let extractor = Extractor<Root, Value>(tag: embedTag)
-    cachedExtractor = extractor
-    return metadata.tag(of: root) == embedTag ? value : nil
-
-    #endif
   }
 }
 
@@ -133,13 +113,6 @@ public func extract<Root, Value>(_ embed: @escaping (Value) -> Root) -> (Root) -
 
 // This is the size of any Unsafe*Pointer and also the size of Int and UInt.
 private let pointerSize = MemoryLayout<UnsafeRawPointer>.size
-
-private typealias OpaqueExistentialContainer = (
-  UnsafeMutableRawPointer?, UnsafeMutableRawPointer?, UnsafeMutableRawPointer?,
-  metadata: UnsafeRawPointer?
-)
-
-private typealias BoxPair = (heapObject: UnsafeMutableRawPointer, buffer: UnsafeMutableRawPointer)
 
 extension UnsafeRawPointer {
   fileprivate func loadInferredType<Type>() -> Type {
@@ -154,28 +127,6 @@ extension UnsafeRawPointer {
 
 private struct ValueWitnessTable {
   let ptr: UnsafeRawPointer
-
-  var flags: Flags {
-    return Flags(rawValue: ptr.advanced(by: 10 * pointerSize).load(as: UInt32.self))
-  }
-
-  var initializeWithCopy:
-    @convention(c) (
-      _ dest: UnsafeMutableRawPointer, _ source: UnsafeMutableRawPointer,
-      _ metadata: UnsafeRawPointer
-    ) -> UnsafeMutableRawPointer
-  {
-    return ptr.advanced(by: 2 * pointerSize).loadInferredType()
-  }
-
-  var initializeWithTake:
-    @convention(c) (
-      _ dest: UnsafeMutableRawPointer, _ source: UnsafeMutableRawPointer,
-      _ metadata: UnsafeRawPointer
-    ) -> UnsafeMutableRawPointer
-  {
-    return ptr.advanced(by: 4 * pointerSize).loadInferredType()
-  }
 
   var getEnumTag: @convention(c) (_ value: UnsafeRawPointer, _ metadata: UnsafeRawPointer) -> UInt32
   {
@@ -197,14 +148,6 @@ private struct ValueWitnessTable {
   }
 }
 
-extension ValueWitnessTable {
-  struct Flags: OptionSet {
-    var rawValue: UInt32
-
-    static var isNonInline: Self { .init(rawValue: 0x020000) }
-  }
-}
-
 private struct GenericArgumentVector {
   let ptr: UnsafeRawPointer
 }
@@ -217,15 +160,15 @@ private struct MetadataKind: Equatable {
   // 0x201 = MetadataKind::Enum
   // 0x202 = MetadataKind::Optional
   // 0x301 = MetadataKind::Tuple
+  // 0x303 = MetadataKind::Existential
   static var enumeration: Self { .init(rawValue: 0x201) }
   static var optional: Self { .init(rawValue: 0x202) }
   static var tuple: Self { .init(rawValue: 0x301) }
+  static var existential: Self { .init(rawValue: 0x303) }
 }
 
 private protocol Metadata {
   var ptr: UnsafeRawPointer { get }
-
-  var genericArguments: GenericArgumentVector? { get }
 }
 
 extension Metadata {
@@ -235,41 +178,6 @@ extension Metadata {
   }
 
   var kind: MetadataKind { ptr.load(as: MetadataKind.self) }
-
-  func initialize(_ dest: UnsafeMutableRawPointer, byCopying source: UnsafeMutableRawPointer) {
-    _ = valueWitnessTable.initializeWithCopy(dest, source, ptr)
-  }
-
-  func initialize(_ dest: UnsafeMutableRawPointer, byTaking source: UnsafeMutableRawPointer) {
-    _ = valueWitnessTable.initializeWithTake(dest, source, ptr)
-  }
-
-  func allocateBoxForExistential(in buffer: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer {
-    guard valueWitnessTable.flags.contains(.isNonInline) else {
-      return buffer
-    }
-
-    let (heapObject:heapObject, buffer:boxBuffer) = swift_allocBox(for: ptr)
-    buffer.storeBytes(of: heapObject, as: UnsafeMutableRawPointer.self)
-    return boxBuffer
-  }
-
-  func deallocateBoxForExistential(in buffer: UnsafeMutableRawPointer) {
-    guard valueWitnessTable.flags.contains(.isNonInline) else { return }
-    swift_deallocBox(buffer.load(as: UnsafeMutableRawPointer.self))
-  }
-}
-
-private struct UnknownMetadata: Metadata {
-  let ptr: UnsafeRawPointer
-
-  var genericArguments: GenericArgumentVector? { nil }
-}
-
-extension UnknownMetadata {
-  init(_ type: Any.Type) {
-    ptr = unsafeBitCast(type, to: UnsafeRawPointer.self)
-  }
 }
 
 private struct EnumMetadata: Metadata {
@@ -285,7 +193,7 @@ private struct EnumMetadata: Metadata {
   }
 
   var genericArguments: GenericArgumentVector? {
-    guard isGeneric else { return nil }
+    guard typeDescriptor.flags.contains(.isGeneric) else { return nil }
     return .init(ptr: ptr.advanced(by: 2 * pointerSize))
   }
 
@@ -293,8 +201,6 @@ private struct EnumMetadata: Metadata {
     return EnumTypeDescriptor(
       ptr: ptr.advanced(by: pointerSize).load(as: UnsafeRawPointer.self))
   }
-
-  var isGeneric: Bool { typeDescriptor.flags.contains(.isGeneric) }
 
   func tag<Enum>(of value: Enum) -> UInt32 {
     return withUnsafePointer(to: value) {
@@ -306,17 +212,17 @@ private struct EnumMetadata: Metadata {
 extension EnumMetadata {
   func associatedValueType(forTag tag: UInt32) -> Any.Type {
     guard
-      let typeName = typeDescriptor.fieldDescriptor?.field(atIndex: tag).typeName
+      let typeName = typeDescriptor.fieldDescriptor?.field(atIndex: tag).typeName,
+      let type = swift_getTypeByMangledNameInContext(
+        typeName.ptr, typeName.length,
+        genericContext: typeDescriptor.ptr,
+        genericArguments: genericArguments?.ptr)
     else {
       // There's not really a good answer for this. Void is a safe answer since it's zero-size.
       return Void.self
     }
 
-    return swift_getTypeByMangledNameInContext(
-      typeName.ptr, typeName.length,
-      genericContext: typeDescriptor.ptr,
-      genericArguments: genericArguments?.ptr)
-      ?? Void.self
+    return type
   }
 }
 
@@ -332,52 +238,39 @@ extension EnumMetadata {
 
 /// The strategy to use to extract the associated value of a specific case of `Enum` as a `Value`.
 private enum Extractor<Enum, Value> {
-  // The case is layout-compatible with `Value`, after tag-stripping (aka projection).
+  case unimplemented(tag: UInt32)
+
+  /// The case is layout-compatible with `Value`, after tag-stripping (aka projection).
   case direct(tag: UInt32)
 
-  // The case stores its associated value indirectly. The case payload is a pointer to a heap object. The heap object's payload is layout-compatible with `Value`.
+  /// The case stores its associated value indirectly. The case payload is a pointer to a heap object. The heap object's payload is layout-compatible with `Value`.
   case indirect(tag: UInt32)
 
-  // The case directly stores a protocol existential. `Value` conforms to that protocol.
-  case directExistential(tag: UInt32)
-
-  // The case indirectly stores a protocol existential. `Value` conforms to that protocol.
-  case indirectExistential(tag: UInt32)
+  /// The case stores a protocol existential, either directly or indirectly. This extractor type is only used when the enum case's associated value type is a protocol existential and the `CasePath`'s `Value` is a type that conforms to the protocol (but is not itself the protocol existential).
+  case existential(tag: UInt32, get: (Enum) -> Any?)
 }
 
 extension Extractor {
   var tag: UInt32 {
     switch self {
     case
+      .unimplemented(tag: let tag),
       .direct(tag: let tag),
       .indirect(tag: let tag),
-      .directExistential(tag: let tag),
-      .indirectExistential(tag: let tag):
+      .existential(tag: let tag, get: _):
       return tag
     }
   }
 }
 
 extension Extractor {
-  init(tag: UInt32) {
-    self = EnumMetadata(assumingEnum: Enum.self)
-      .typeDescriptor
-      .fieldDescriptor!
-      .field(atIndex: tag).isIndirectCase
-      ? .indirect(tag: tag)
-      : .direct(tag: tag)
-  }
-}
-
-extension Extractor {
-  init?(root: Enum) {
+  /// Create the appropriate `Extractor` to extract a `Value` from an `Enum` if that `Enum`'s case tag is `tag`. If `assumedAssociatedValueType` is nil, I'll look up the associated value type in the `Enum` metadata.
+  init?(tag: UInt32, assumedAssociatedValueType: Any.Type? = nil) {
     let metadata = EnumMetadata(assumingEnum: Enum.self)
-    let tag = metadata.tag(of: root)
-    let avType = metadata.associatedValueType(forTag: tag)
+    let avType = assumedAssociatedValueType ?? metadata.associatedValueType(forTag: tag)
 
-    guard avType != Value.self else {
-      self = .init(tag: tag)
-      return
+    if avType == Value.self {
+      self = .init(nonExistentialTag: tag)
     }
 
     // Consider this: `enum E { case c(l: Int) }`
@@ -391,16 +284,14 @@ extension Extractor {
     // The types `(l: Int)` and `Int` use the same memory layout.
     //
     // So if `avType` is a single-element tuple and `Value` is the type of that tuple's single element, I can extract a `Value` from `root`.
-    if
+    else if
       let avMetadata = TupleMetadata(avType),
-      avMetadata.elementCount == 1,
-      avMetadata.element(at: 0).type == Value.self
+      avMetadata.elementCount == 1
     {
-      self = .init(tag: tag)
-      return
+      self.init(tag: tag, assumedAssociatedValueType: avMetadata.element(at: 0).type)
     }
 
-    // Consider these: `enum F { case d(a: Int, b: String) }`
+    // Consider this: `enum F { case d(a: Int, b: String) }`
     //
     // Certainly we should allow `CasePath<F, (a: Int, b: String)>` to match this.
     //
@@ -409,33 +300,101 @@ extension Extractor {
     // So if `avType` is a tuple, and `Value` is a tuple with no labels, and the two types have identical elements types, I can extract a `Value` from `root`.
     //
     // If `Value` has labels, that doesn't change its memory layout. But I don't want to silently transform a tuple that was created as `(x: 1, y: 2)` into a differently-labeled tuple `(y: 1, x: 2)`.
-    if
-      TupleMetadata(avType) != nil,
+    else if
+      let avMetadata = TupleMetadata(avType),
       let valueMetadata = TupleMetadata(Value.self),
       valueMetadata.labels == nil
     {
-      self = .init(tag: tag)
+      // Consider this:
+      //
+      // ```
+      // protocol P { }
+      // extension Int: P { }
+      // enum Enum {
+      //     case c(P, Int)
+      // }
+      // let (i: Int, j: Int)? = (/E.c).extract(E.c(34, 12))
+      // ```
+      //
+      // See the handling of existentials later in this method for a simpler scenario that I do handle. But here, avType and Value are tuples with the same element count but different memory layout, because avType has a P existential where Value has an Int.
+      //
+      // This is an extremely rare scenario and I think it's too much work to try to handle it.
+      guard avMetadata.hasSameLayout(as: valueMetadata) else {
+        #if DEBUG
+        print("CasePath<\(Enum.self), \(Value.self)> has not been programmed to convert an \(avType) to a \(Value.self).")
+        #endif
+        self = .unimplemented(tag: tag)
+        return
+      }
+
+      self.init(tag: tag, assumedAssociatedValueType: Value.self)
       return
     }
 
-    return nil
+    // Consider this:
+    //
+    // ```
+    // protocol P { }
+    // extension Int: P { }
+    // enum E { case c(P) }
+    //
+    // let i: Int? = (/E.c).extract(E.c(100))
+    // ```
+    //
+    // Even though the associated value type is `P`, and `E.c(_:)`'s type is `(P) -> E`, this constructs a `CasePath<E, Int>`, not a `CasePath<E, P>`. Here's why:
+    //
+    // - The context requires the `CasePath`'s `Value` type to be `Int`.
+    //
+    // - Therefore the `/` prefix operator requires its argument to have type `(Int) -> E`.
+    //
+    // - `(P) -> E` is a subtype of `(Int) -> E`, because `P` is in contravariant position and `Int` is a subtype of `P`.
+    //
+    // - Therefore Swift converts `E.c(_:)` to the supertype `(Int) -> E` automatically to make the expression type-check.
+    //
+    // This circumstance is unfortunate, but I don't know how to diagnose it at compile-time. So I want to handle it in a reasonable way.
+    //
+    // If `avType` is a protocol existential (a “box”), then I can extract the box from `root` and look at the boxed type. If the boxed type is `Value`, then I can extract `Value` from the box.
+    //
+    // Ideally I would check that Value actually conforms to avType's protocol. Unfortunately, the metedata doesn't include conformance information. I'd have to dig through the conformance sections of the executable file and shared libraries. It's not worth the trouble.
+    else if
+      ExistentialMetadata(avType) != nil
+    {
+      // I can use `Any` as the value type because it's compatible with any protocol existential.
+      let anyExtractor = Extractor<Enum, Any>(nonExistentialTag: tag)
+      self = .existential(tag: tag) { anyExtractor.extract(from: $0) }
+    }
+
+    else {
+      return nil
+    }
+  }
+
+  init(nonExistentialTag tag: UInt32) {
+    self = EnumMetadata(assumingEnum: Enum.self)
+      .typeDescriptor
+      .fieldDescriptor!
+      .field(atIndex: tag)
+      .flags
+      .contains(.isIndirectCase)
+      ? .indirect(tag: tag)
+      : .direct(tag: tag)
   }
 }
 
 extension Extractor {
   func extract(from root: Enum) -> Value? {
     switch self {
-    case .direct(let tag):
+    case .unimplemented(tag: _):
+      return nil
+
+    case .direct(tag: let tag):
       return extractDirect(from: root, tag: tag)
 
-    case .indirect(let tag):
+    case .indirect(tag: let tag):
       return extractIndirect(from: root, tag: tag)
 
-    case .directExistential(tag: _):
-      fatalError()
-
-    case .indirectExistential(tag: _):
-      fatalError()
+    case .existential(tag: let tag, get: let get):
+      return extractThroughExistential(from: root, tag: tag, get: get)
     }
   }
 
@@ -455,6 +414,15 @@ extension Extractor {
         .advanced(by: 2 * pointerSize) // Skip the heap object header.
         .load(as: Value.self)
     }
+  }
+
+  private func extractThroughExistential(from root: Enum, tag: UInt32, get: (Enum) -> Any?) -> Value? {
+    guard
+      EnumMetadata(assumingEnum: Enum.self).tag(of: root) == tag,
+      let any = get(root),
+      let value = any as? Value
+    else { return nil }
+    return .some(value)
   }
 
   private func withProjectedPayload<Enum, Answer>(
@@ -483,18 +451,6 @@ extension Extractor {
   }
 }
 
-@_silgen_name("swift_allocBox")
-private func swift_allocBox(for metadata: UnsafeRawPointer) -> BoxPair
-
-@_silgen_name("swift_deallocBox")
-private func swift_deallocBox(_ heapObject: UnsafeMutableRawPointer)
-
-@_silgen_name("swift_projectBox")
-private func swift_projectBox(_ heapObject: UnsafeMutableRawPointer) -> UnsafeMutableRawPointer
-
-@_silgen_name("swift_release")
-private func swift_release(_ heapObject: UnsafeMutableRawPointer)
-
 @_silgen_name("swift_getTypeByMangledNameInContext")
 private func swift_getTypeByMangledNameInContext(
   _ name: UnsafePointer<UInt8>,
@@ -513,10 +469,6 @@ private struct EnumTypeDescriptor {
       .advanced(by: 4 * 4)
       .loadRelativePointer()
       .map(FieldDescriptor.init)
-  }
-
-  var numPayloadCases: Int32 {
-    return ptr.advanced(by: 5 * 4).load(as: Int32.self) & 0xFFFFFF
   }
 }
 
@@ -551,8 +503,6 @@ private struct FieldRecord {
       .loadRelativePointer()
       .map { MangledTypeName(ptr: $0.assumingMemoryBound(to: UInt8.self)) }
   }
-
-  var isIndirectCase: Bool { flags.contains(.isIndirectCase) }
 }
 
 extension FieldRecord {
@@ -598,8 +548,6 @@ private struct TupleMetadata: Metadata {
     guard kind == .tuple else { return nil }
   }
 
-  var genericArguments: GenericArgumentVector? { nil }
-
   var elementCount: UInt {
     return ptr
       .advanced(by: pointerSize) // kind
@@ -624,48 +572,30 @@ private struct TupleMetadata: Metadata {
 }
 
 extension TupleMetadata {
-  struct Element {
+  struct Element: Equatable {
     let ptr: UnsafeRawPointer
 
     var type: Any.Type { ptr.load(as: Any.Type.self) }
     var offset: UInt { ptr.advanced(by: pointerSize).load(as: UInt.self) }
+
+    static func ==(lhs: Element, rhs: Element) -> Bool {
+      return lhs.type == rhs.type && lhs.offset == rhs.offset
+    }
   }
 }
 
-#if compiler(<5.2)
-
-  // https://bugs.swift.org/browse/SR-12044
-  private func workaroundForSR12044<Value>(_ type: Value.Type) -> Value? {
-    // If Value is an inhabited type with a size of zero, Mirror doesn't notice it as the associated value of an enum case due to incorrect metadata. But, being inhabited with a size of zero, it has only one possible inhabitant, so I create the inhabitant here using unsafeBitCast.
-
-    // An uninhabited type like Never also has a size of zero, and I have to be careful not to create a value of an uninhabited type.
-
-    // It's possible for a tuple, struct, or class to be uninhabited by having an uninhabited stored property. But detecting such a type is difficult as I'd have to scrounge through even more metadata. So instead I'm just checking for the common case of an uninhabited enum. If you do something like `enum E { case c(Never, Never) }`... you have my sincere apology.
-
-    if MemoryLayout<Value>.size == 0,
-      !isUninhabitedEnum(Value.self)
-    {
-      return unsafeBitCast((), to: Value.self)
-    }
-    return nil
+extension TupleMetadata {
+  func hasSameLayout(as other: TupleMetadata) -> Bool {
+    return self.elementCount == other.elementCount &&
+      (0 ..< Int(elementCount)).allSatisfy { self.element(at: $0) == other.element(at: $0) }
   }
+}
 
-  private func isUninhabitedEnum(_ type: Any.Type) -> Bool {
-    // If it lacks enum metadata, it's definitely not an uninhabited enum.
-    guard let metadata = EnumMetadata(type) else { return false }
-    return !metadata.typeDescriptor.isInhabited
+private struct ExistentialMetadata: Metadata {
+  let ptr: UnsafeRawPointer
+
+  init?(_ type: Any.Type?) {
+    ptr = unsafeBitCast(type, to: UnsafeRawPointer.self)
+    guard kind == .existential else { return nil }
   }
-
-  extension EnumTypeDescriptor {
-    var numEmptyCases: Int32 {
-      return ptr.advanced(by: 6 * 4).load(as: Int32.self)
-    }
-
-    var isInhabited: Bool { numPayloadCases + numEmptyCases > 0 }
-  }
-
-#else
-
-  private func workaroundForSR12044<Value>(_ type: Value.Type) -> Value? { nil }
-
-#endif
+}

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -171,8 +171,8 @@ extension ValueWitnessTable {
 private struct MetadataKind: Equatable {
   var rawValue: UInt
 
-  // https://github.com/apple/swift/blob/master/include/swift/ABI/MetadataValues.h
-  // https://github.com/apple/swift/blob/master/include/swift/ABI/MetadataKind.def
+  // https://github.com/apple/swift/blob/main/include/swift/ABI/MetadataValues.h
+  // https://github.com/apple/swift/blob/main/include/swift/ABI/MetadataKind.def
   // 0x201 = MetadataKind::Enum
   // 0x202 = MetadataKind::Optional
   static var enumeration: Self { .init(rawValue: 0x201) }
@@ -241,7 +241,7 @@ private struct EnumMetadata: Metadata {
 
   func indirectAssociatedValue<Enum, Value>(of enumCase: Enum, as type: Value.Type) -> Value {
     // This is closely based on EnumImpl::subscript.
-    // https://github.com/apple/swift/blob/master/stdlib/public/runtime/ReflectionMirror.cpp
+    // https://github.com/apple/swift/blob/main/stdlib/public/runtime/ReflectionMirror.cpp
 
     // I'll need access to this thing's bytes, which means it has to be a var.
     var enumCase = enumCase

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -84,11 +84,12 @@ public func extract<Root, Value>(_ embed: @escaping (Value) -> Root) -> (Root) -
 
   var cachedExtractor: Extractor<Root, Value>? = nil
   return { root in
-    if let extractor = cachedExtractor {
-      return extractor.extract(from: root)
-    }
-
     let metadata = EnumMetadata(assumingEnum: Root.self)
+
+    if let cachedTag = cachedExtractor?.tag {
+      guard metadata.tag(of: root) == cachedTag else { return nil }
+      return cachedExtractor.unsafelyUnwrapped.extract(from: root)
+    }
 
     guard
       let rootExtractor = Extractor<Root, Value>(tag: metadata.tag(of: root)),

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -94,7 +94,7 @@ public func extract<Root, Value>(_ embed: @escaping (Value) -> Root) -> (Root) -
     }
 
     guard
-      let rootStrategy = Strategy<Root, Value>(tag: metadata.tag(of: root)),
+      let rootStrategy = Strategy<Root, Value>(tag: rootTag),
       let value = rootStrategy.extract(from: root, tag: rootTag)
     else {
       return nil

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -360,7 +360,25 @@ final class CasePathsTests: XCTestCase {
 
   func testContravariantEmbed() {
     enum Enum {
-      case p(TestProtocol)
+      // associated value type is TestProtocol existential
+      case directExistential(TestProtocol)
+
+      // associated value type is single-element tuple (TestProtocol existential)
+      case directTuple(label: TestProtocol)
+
+      indirect case indirectExistential(TestProtocol)
+
+      indirect case indirectTuple(label: TestProtocol)
+
+      static let cdeCase = Enum.directExistential(Conformer())
+      static let cdtCase = Enum.directTuple(label: Conformer())
+      static let cieCase = Enum.indirectExistential(Conformer())
+      static let citCase = Enum.indirectTuple(label: Conformer())
+
+      static let ideCase = Enum.directExistential(100)
+      static let idtCase = Enum.directTuple(label: 100)
+      static let iieCase = Enum.indirectExistential(100)
+      static let iitCase = Enum.indirectTuple(label: 100)
     }
 
     // This is intentionally too big to fit in the three-word buffer of a protocol existential, so that it is stored indirectly.
@@ -371,12 +389,48 @@ final class CasePathsTests: XCTestCase {
       }
     }
 
-    let path: CasePath<Enum, Conformer> = /Enum.p
+    let dePath: CasePath<Enum, Conformer> = /Enum.directExistential
+    let dtPath: CasePath<Enum, Conformer> = /Enum.directTuple
+    let iePath: CasePath<Enum, Conformer> = /Enum.indirectExistential
+    let itPath: CasePath<Enum, Conformer> = /Enum.indirectTuple
 
     for _ in 1...2 {
-      XCTAssertEqual(
-        path.extract(from: .p(Conformer())),
-        .some(Conformer()))
+      XCTAssertNil(dePath.extract(from: .cdtCase))
+      XCTAssertNil(dePath.extract(from: .cieCase))
+      XCTAssertNil(dePath.extract(from: .citCase))
+      XCTAssertNil(dePath.extract(from: .ideCase))
+      XCTAssertNil(dePath.extract(from: .idtCase))
+      XCTAssertNil(dePath.extract(from: .iieCase))
+      XCTAssertNil(dePath.extract(from: .iitCase))
+      XCTAssertEqual(dePath.extract(from: .cdeCase), .some(Conformer()))
+
+      XCTAssertNil(dtPath.extract(from: .cdeCase))
+      XCTAssertNil(dtPath.extract(from: .cieCase))
+      XCTAssertNil(dtPath.extract(from: .citCase))
+      XCTAssertNil(dtPath.extract(from: .ideCase))
+      XCTAssertNil(dtPath.extract(from: .idtCase))
+      XCTAssertNil(dtPath.extract(from: .iieCase))
+      XCTAssertNil(dtPath.extract(from: .iitCase))
+      XCTAssertEqual(dtPath.extract(from: .cdtCase), .some(Conformer()))
+
+      XCTAssertNil(iePath.extract(from: .cdeCase))
+      XCTAssertNil(iePath.extract(from: .cdtCase))
+      XCTAssertNil(iePath.extract(from: .cieCase))
+      XCTAssertNil(iePath.extract(from: .citCase))
+      XCTAssertNil(iePath.extract(from: .ideCase))
+      XCTAssertNil(iePath.extract(from: .idtCase))
+      XCTAssertNil(iePath.extract(from: .iieCase))
+      XCTAssertNil(iePath.extract(from: .iitCase))
+      XCTAssertEqual(iePath.extract(from: .cieCase), .some(Conformer()))
+
+      XCTAssertNil(itPath.extract(from: .cdeCase))
+      XCTAssertNil(itPath.extract(from: .cdtCase))
+      XCTAssertNil(itPath.extract(from: .cieCase))
+      XCTAssertNil(itPath.extract(from: .ideCase))
+      XCTAssertNil(itPath.extract(from: .idtCase))
+      XCTAssertNil(itPath.extract(from: .iieCase))
+      XCTAssertNil(itPath.extract(from: .iitCase))
+      XCTAssertEqual(itPath.extract(from: .citCase), .some(Conformer()))
     }
   }
 

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -395,6 +395,7 @@ final class CasePathsTests: XCTestCase {
     let itPath: CasePath<Enum, Conformer> = /Enum.indirectTuple
 
     for _ in 1...2 {
+
       XCTAssertNil(dePath.extract(from: .cdtCase))
       XCTAssertNil(dePath.extract(from: .cieCase))
       XCTAssertNil(dePath.extract(from: .citCase))
@@ -415,7 +416,6 @@ final class CasePathsTests: XCTestCase {
 
       XCTAssertNil(iePath.extract(from: .cdeCase))
       XCTAssertNil(iePath.extract(from: .cdtCase))
-      XCTAssertNil(iePath.extract(from: .cieCase))
       XCTAssertNil(iePath.extract(from: .citCase))
       XCTAssertNil(iePath.extract(from: .ideCase))
       XCTAssertNil(iePath.extract(from: .idtCase))
@@ -431,6 +431,19 @@ final class CasePathsTests: XCTestCase {
       XCTAssertNil(itPath.extract(from: .iieCase))
       XCTAssertNil(itPath.extract(from: .iitCase))
       XCTAssertEqual(itPath.extract(from: .citCase), .some(Conformer()))
+    }
+  }
+
+  func testUnreasonableContravariantEmbed() {
+    enum Enum {
+      case c(TestProtocol, Int)
+    }
+
+    // The library doesn't handle this crazy esoteric case, but it detects it and returns nil instead of garbage.
+    let path: CasePath<Enum, (Int, Int)> = /Enum.c
+
+    for _ in 1...2 {
+      XCTAssertNil(path.extract(from: .c(34, 12)))
     }
   }
 

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -358,6 +358,28 @@ final class CasePathsTests: XCTestCase {
     }
   }
 
+  func testContravariantEmbed() {
+    enum Enum {
+      case p(TestProtocol)
+    }
+
+    // This is intentionally too big to fit in the three-word buffer of a protocol existential, so that it is stored indirectly.
+    struct Conformer: TestProtocol, Equatable {
+      var a, b, c, d: Int
+      init() {
+        (a, b, c, d) = (100, 300, 200, 400)
+      }
+    }
+
+    let path: CasePath<Enum, Conformer> = /Enum.p
+
+    for _ in 1...2 {
+      XCTAssertEqual(
+        path.extract(from: .p(Conformer())),
+        .some(Conformer()))
+    }
+  }
+
   func testEmbed() {
     enum Foo: Equatable { case bar(Int) }
 

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -590,6 +590,21 @@ final class CasePathsTests: XCTestCase {
     )
   }
 
+  func testCompoundUninhabitedType() {
+    // Under Swift 5.1 (Xcode 11.3), this test creates a bogus instance of the tuple `(Never, Never)`, but remarkably, doesn't cause a crash and extracts the correct answer (nil).
+
+    enum Enum {
+      case nevers(Never, Never)
+      case something(Void)
+    }
+
+    let path: CasePath<Enum, (Never, Never)> = /Enum.nevers(_:_:)
+
+    for _ in 1...2 {
+      XCTAssertNil(path.extract(from: Enum.something(())))
+    }
+  }
+
   func testNestedUninhabitedTypes() {
     enum Uninhabited {}
 

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -8,6 +8,9 @@ private func unwrap<Wrapped>(_ optional: Wrapped?) throws -> Wrapped {
 }
 private struct UnexpectedNil: Error {}
 
+protocol TestProtocol { }
+extension Int: TestProtocol { }
+
 final class CasePathsTests: XCTestCase {
   func testSimplePayload() {
     enum Enum { case payload(Int) }
@@ -334,6 +337,24 @@ final class CasePathsTests: XCTestCase {
       XCTAssertNotNil(intPath.extract(from: .int(42)))
       XCTAssertNotNil(voidPath.extract(from: .void(())))
       XCTAssertNotNil(anyPath.extract(from: .any("Blob")))
+    }
+  }
+
+  func testAssociatedValueIsExistential() {
+    enum Enum {
+        case proto(TestProtocol)
+        case int(Int)
+    }
+
+    let protoPath = /Enum.proto
+    let intPath = /Enum.int
+
+    for _ in 1...2 {
+        XCTAssertNil(protoPath.extract(from: .int(100)))
+        XCTAssertEqual(protoPath.extract(from: .proto(100)) as? Int, 100)
+
+        XCTAssertNil(intPath.extract(from: .proto(100)))
+        XCTAssertEqual(intPath.extract(from: .int(100)), 100)
     }
   }
 


### PR DESCRIPTION
This branch is not ready for merging. I'm creating this pull request only to make it available for discussion.

I found example uses of `swift_getTypeByMangledNameInContext` in [the Reflect package](https://github.com/wickwirew/Runtime) and have made some progress toward using it to replace the use of `Mirror`.

In its current state, this branch has several failing tests, all related to associated value labels. I've outlined what's wrong and what needs to be done in the commit message and code comments.