### PR TITLE
Stylistic cleanup for metadata extraction

### DIFF
--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -87,16 +87,19 @@ public func extract<Root, Value>(_ embed: @escaping (Value) -> Root) -> (Root) -
       return cachedStrategy.extract(from: root, tag: rootTag)
     }
 
-    guard let value = Strategy<Root, Value>(tag: rootTag).extract(from: root, tag: rootTag)
+    let rootStrategy = Strategy<Root, Value>(tag: rootTag)
+    guard let value = rootStrategy.extract(from: root, tag: rootTag)
     else { return nil }
 
     let embedTag = metadata.tag(of: embed(value))
     cachedTag = embedTag
-    cachedStrategy = Strategy<Root, Value>(tag: embedTag)
-
-    guard embedTag == rootTag else { return nil }
-
-    return value
+    if embedTag == rootTag {
+      cachedStrategy = rootStrategy
+      return value
+    } else {
+      cachedStrategy = Strategy<Root, Value>(tag: embedTag)
+      return nil
+    }
   }
 }
 

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -6,7 +6,7 @@ extension CasePath {
   /// - Parameter embed: An enum case initializer.
   /// - Returns: A case path that extracts associated values from enum cases.
   public static func `case`(_ embed: @escaping (Value) -> Root) -> CasePath {
-    return self.init(
+    self.init(
       embed: embed,
       extract: CasePaths.extract(embed)
     )
@@ -67,89 +67,48 @@ public func extract<Root, Value>(case embed: @escaping (Value) -> Root, from roo
 /// - Parameter embed: An enum case initializer.
 /// - Returns: A function that can attempt to extract associated values from an enum.
 public func extract<Root, Value>(_ embed: @escaping (Value) -> Root) -> (Root) -> (Value?) {
-  guard let metadata = EnumMetadata(Root.self) else {
-    #if DEBUG
-      print(
-        "\(#function) can never extract values from \(Root.self) because \(Root.self) isn't an enum!"
-      )
-    #endif
-    return { _ in nil }
-  }
+  guard
+    let metadata = EnumMetadata(Root.self),
+    metadata.typeDescriptor.fieldDescriptor != nil
+  else { return { _ in nil } }
 
-  guard metadata.typeDescriptor.fieldDescriptor != nil else {
-    #if DEBUG
-      print(
-        "\(#function) can never extract values from \(Root.self) because the metadata for \(Root.self) is incomplete!"
-      )
-    #endif
-    return { _ in nil }
-  }
+  var cachedTag: UInt32?
+  var cachedStrategy: Strategy<Root, Value>?
 
-  var cachedTag: UInt32? = nil
-  var cachedStrategy: Strategy<Root, Value> = .unimplemented
   return { root in
     let metadata = EnumMetadata(assumingEnum: Root.self)
     let rootTag = metadata.tag(of: root)
 
-    if let cachedTag = cachedTag {
+    if let cachedTag = cachedTag, let cachedStrategy = cachedStrategy {
       guard rootTag == cachedTag else { return nil }
       return cachedStrategy.extract(from: root, tag: rootTag)
     }
 
-    guard
-      let rootStrategy = Strategy<Root, Value>(tag: rootTag),
-      let value = rootStrategy.extract(from: root, tag: rootTag)
-    else {
-      return nil
-    }
+    guard let value = Strategy<Root, Value>(tag: rootTag).extract(from: root, tag: rootTag)
+    else { return nil }
 
-    let embeddedValue = embed(value)
-    let embedTag = metadata.tag(of: embeddedValue)
+    let embedTag = metadata.tag(of: embed(value))
     cachedTag = embedTag
+    cachedStrategy = Strategy<Root, Value>(tag: embedTag)
 
-    guard cachedTag == rootTag else {
-      // I have the correct tag now, so I can now pick the correct strategy, even if I won't use it this time.
-      if let embedStrategy = Strategy<Root, Value>(tag: embedTag) {
-        cachedStrategy = embedStrategy
-      } else {
-        #if DEBUG
-          print(
-            "\(#function) can never extract values from a \(Root.self) case like \(embeddedValue) because I don't know how to convert its associated value to \(Value.self)!"
-          )
-        #endif
-        cachedStrategy = .unimplemented
-      }
+    guard cachedTag == rootTag else { return nil }
 
-      return nil
-    }
-
-    cachedStrategy = rootStrategy
     return value
   }
 }
 
 // MARK: - Private Helpers
 
-/// A `Strategy` is a way of extracting an associated value from an enum case.
-enum Strategy<Enum, Value> {
-  case unimplemented
-
-  /// The case's associated type is a zero-size inhabited type, so it only has a single possible inhabitant, which I can synthesize.
-  case void
-
-  /// The case is layout-compatible with `Value`, after tag-stripping (aka projection).
+private enum Strategy<Enum, Value> {
   case direct
-
-  /// The case stores its associated value indirectly. The case payload is a pointer to a heap object. The heap object's payload is layout-compatible with `Value`.
+  case existential(extract: (Enum) -> Any?)
   case indirect
-
-  /// The case stores a protocol existential, either directly or indirectly. This strategy is used when the enum case's associated value type is a protocol existential and the `CasePath`'s `Value` is a type that conforms to the protocol (but is not itself the protocol existential).
-  case existential(get: (Enum) -> Any?)
+  case unimplemented
+  case void
 }
 
 extension Strategy {
-  /// Choose the appropriate `Strategy` to extract a `Value` from an `Enum` if that `Enum`'s case tag is `tag`. If `assumedAssociatedValueType` is nil, I'll look up the associated value type in the `Enum` metadata.
-  init?(tag: UInt32, assumedAssociatedValueType: Any.Type? = nil) {
+  init(tag: UInt32, assumedAssociatedValueType: Any.Type? = nil) {
     let metadata = EnumMetadata(assumingEnum: Enum.self)
     let avType = assumedAssociatedValueType ?? metadata.associatedValueType(forTag: tag)
 
@@ -162,124 +121,40 @@ extension Strategy {
     }
 
     var isUninhabitedEnum: Bool {
-      // If it lacks enum metadata, it's definitely not an uninhabited enum.
-      return metadata.typeDescriptor.emptyCaseCount == 0
-        && metadata.typeDescriptor.payloadCaseCount == 0
+      metadata.typeDescriptor.emptyCaseCount == 0 && metadata.typeDescriptor.payloadCaseCount == 0
     }
 
     if avType == Value.self {
-      // The `CasePath`'s `Value` type is exactly the case's associated value type.
       self = .init(nonExistentialTag: tag)
-    }
 
-    // If `Value` is an inhabited type with size zero, it has a single inhabitant which I can synthesize by bit-casting `()`.
-    //
-    // I handle this specially because it works around a Swift 5.1 bug:
-    // https://bugs.swift.org/browse/SR-12044
-    //
-    // When the payload is a size-zero type, Swift 5.1 omits the typeName in the metadata describing the `tag` case, and `associatedValueType(forTag:)` returns `Void.self` in that case. This bug was corrected in Swift 5.2.
-    //
-    // An uninhabited type like Never also has a size of zero. I have to be careful not to create a value of an uninhabited type.
-    //
-    // If you do something like `enum E { case c(Never, Never) }`, I don't detect that it's an uninhabited tuple and I'll end up creating a bogus value of type `(Never, Never)` and it'll get passed to the `E.c` initializer. Remarkably, the initializer doesn't care! It creates the `E` value anyway. Since there is no safe way to create an `E.c` value, the `E.c` tag can't match the tag of the actual `E` value being checked by the `CasePath`. So the `CasePath` won't end up extracting a bogus value.
-    else if shouldWorkAroundSR12044,
-      MemoryLayout<Value>.size == 0,
-      !isUninhabitedEnum
-    {
+    } else if shouldWorkAroundSR12044, MemoryLayout<Value>.size == 0, !isUninhabitedEnum {
+      // Workaround for https://bugs.swift.org/browse/SR-12044
       self = .void
-    }
 
-    // Consider this: `enum E { case c(l: Int) }`
-    //
-    // At the metadata level, c's associated value has type `(l: Int)`, which is a single-element tuple.
-    //
-    // But Swift doesn't support single-element tuples in Swift source code, so `CasePath<E, (l: Int)>` isn't allowed.
-    //
-    // The case path for `c` therefore has type `CasePath<E, Int>`.
-    //
-    // The types `(l: Int)` and `Int` use the same memory layout.
-    //
-    // So if `avType` is a single-element tuple and `Value` is the type of that tuple's single element, I can extract a `Value` from `root`.
-    else if let avMetadata = TupleMetadata(avType),
-      avMetadata.elementCount == 1
-    {
+    } else if
+      // Drop payload label from metadata, e.g., treat `(foo: Foo)` as `Foo`.
+      let avMetadata = TupleMetadata(avType), avMetadata.elementCount == 1 {
       self.init(tag: tag, assumedAssociatedValueType: avMetadata.element(at: 0).type)
-    }
 
-    // Consider this: `enum F { case d(a: Int, b: String) }`
-    //
-    // Certainly we should allow `CasePath<F, (a: Int, b: String)>` to match this.
-    //
-    // We would also like `CasePath<F, (Int, String)> to match this.
-    //
-    // So if `avType` is a tuple, and `Value` is a tuple with no labels, and the two types have identical elements types, I can extract a `Value` from `root`.
-    //
-    // If `Value` has labels, that doesn't change its memory layout. But I don't want to silently transform a tuple that was created as `(x: 1, y: 2)` into a differently-labeled tuple `(y: 1, x: 2)`.
-    else if let avMetadata = TupleMetadata(avType),
+    } else if
+      // Drop payload labels from metadata, e.g., treat `(foo: Foo, bar: Bar)` as `(Foo, Bar)`.
+      let avMetadata = TupleMetadata(avType),
       let valueMetadata = TupleMetadata(Value.self),
       valueMetadata.labels == nil
     {
-      // Consider this:
-      //
-      // ```
-      // protocol P { }
-      // extension Int: P { }
-      // enum Enum {
-      //     case c(P, Int)
-      // }
-      // let (i: Int, j: Int)? = (/E.c).extract(E.c(34, 12))
-      // ```
-      //
-      // See the handling of existentials later in this method for a simpler scenario that I do handle. But here, avType and Value are tuples with the same element count but different memory layout, because avType has a P existential where Value has an Int.
-      //
-      // This is an extremely rare scenario and I think it's too much work to try to handle it.
       guard avMetadata.hasSameLayout(as: valueMetadata) else {
-        #if DEBUG
-          print(
-            "CasePath<\(Enum.self), \(Value.self)> has not been programmed to convert an \(avType) to a \(Value.self)."
-          )
-        #endif
         self = .unimplemented
         return
       }
-
       self.init(tag: tag, assumedAssociatedValueType: Value.self)
-    }
 
-    // Consider this:
-    //
-    // ```
-    // protocol P { }
-    // extension Int: P { }
-    // enum E { case c(P) }
-    //
-    // let i: Int? = (/E.c).extract(E.c(100))
-    // ```
-    //
-    // Even though the associated value type is `P`, and `E.c(_:)`'s type is `(P) -> E`, this constructs a `CasePath<E, Int>`, not a `CasePath<E, P>`. Here's why:
-    //
-    // - The context requires the `CasePath`'s `Value` type to be `Int`.
-    //
-    // - Therefore the `/` prefix operator requires its argument to have type `(Int) -> E`.
-    //
-    // - `(P) -> E` is a subtype of `(Int) -> E`, because `P` is in contravariant position and `Int` is a subtype of `P`.
-    //
-    // - Therefore Swift converts `E.c(_:)` to the supertype `(Int) -> E` automatically to make the expression type-check.
-    //
-    // This circumstance is unfortunate, but I don't know how to diagnose it at compile-time. So I want to handle it in a reasonable way.
-    //
-    // If `avType` is a protocol existential (a “box”), then I can extract the box from `root` and look at the boxed type. If the boxed type is `Value`, then I can extract `Value` from the box.
-    //
-    // Ideally I would check that Value actually conforms to avType's protocol. Unfortunately, the metedata doesn't include conformance information. I'd have to dig through the conformance sections of the executable file and shared libraries. It's not worth the trouble.
-    else if ExistentialMetadata(avType) != nil {
-      // I can use `Any` as the value type because it's compatible with any protocol existential.
+    } else if ExistentialMetadata(avType) != nil {
+      // Convert protocol existentials to `Any` so that they can be cast (`as? Value`).
       let anyStrategy = Strategy<Enum, Any>(nonExistentialTag: tag)
       self = .existential { anyStrategy.extract(from: $0, tag: tag) }
-    }
 
-    else {
-      // I can't extract a `Value` from the case for `tag`. Presumably it's because the case's associated value is a completely different, unrelated type.
-      return nil
+    } else {
+      self = .unimplemented
     }
   }
 
@@ -297,31 +172,25 @@ extension Strategy {
 
   func extract(from root: Enum, tag: UInt32) -> Value? {
     switch self {
-    case .unimplemented:
-      return nil
-
-    case .void:
-      return .some(unsafeBitCast((), to: Value.self))
-
     case .direct:
-      return withProjectedPayload(of: root, tag: tag) { .some($0.load(as: Value.self)) }
+      return self.withProjectedPayload(of: root, tag: tag) { $0.load(as: Value.self) }
+
+    case let .existential(extract):
+      return extract(root) as? Value
 
     case .indirect:
-      return withProjectedPayload(of: root, tag: tag) {
-        // In an indirect enum case, the payload is a pointer to a heap object. The heap object's payload is the associated value.
-        return
-          $0
+      return self.withProjectedPayload(of: root, tag: tag) {
+        $0
           .load(as: UnsafeRawPointer.self)  // Load the heap object pointer.
           .advanced(by: 2 * pointerSize)  // Skip the heap object header.
           .load(as: Value.self)
       }
 
-    case .existential(let get):
-      guard
-        let any = get(root),
-        let value = any as? Value
-      else { return nil }
-      return .some(value)
+    case .unimplemented:
+      return nil
+
+    case .void:
+      return .some(unsafeBitCast((), to: Value.self))
     }
   }
 
@@ -331,27 +200,15 @@ extension Strategy {
     do body: (UnsafeRawPointer) -> Answer
   ) -> Answer {
     var root = root
-    let answer: Answer = withUnsafeMutableBytes(of: &root) { rawBuffer in
+    return withUnsafeMutableBytes(of: &root) { rawBuffer in
       let pointer = rawBuffer.baseAddress!
       let metadata = EnumMetadata(assumingEnum: Enum.self)
-
-      // On entry, pointer points to some `Enum` value known to the Swift compiler. So on exit, it still needs to point to that `Enum` value, because the compiler wants to destroy the value in the usual way.
-
       metadata.destructivelyProjectPayload(of: pointer)
-      // `pointer` now points to an `Enum` case payload. Tag bits have been set to zero as needed.
-
-      let answer = body(pointer)
-
-      metadata.destructivelyInjectTag(tag, intoPayload: pointer)
-      // `pointer` now points to an `Enum` again.
-
-      return answer
+      defer { metadata.destructivelyInjectTag(tag, intoPayload: pointer) }
+      return body(pointer)
     }
-    return answer
   }
 }
-
-// MARK: -
 
 private protocol Metadata {
   var ptr: UnsafeRawPointer { get }
@@ -359,11 +216,12 @@ private protocol Metadata {
 
 extension Metadata {
   var valueWitnessTable: ValueWitnessTable {
-    return ValueWitnessTable(
-      ptr: ptr.advanced(by: -pointerSize).load(as: UnsafeRawPointer.self))
+    ValueWitnessTable(
+      ptr: self.ptr.load(fromByteOffset: -pointerSize, as: UnsafeRawPointer.self)
+    )
   }
 
-  var kind: MetadataKind { ptr.load(as: MetadataKind.self) }
+  var kind: MetadataKind { self.ptr.load(as: MetadataKind.self) }
 }
 
 private struct MetadataKind: Equatable {
@@ -371,43 +229,38 @@ private struct MetadataKind: Equatable {
 
   // https://github.com/apple/swift/blob/main/include/swift/ABI/MetadataValues.h
   // https://github.com/apple/swift/blob/main/include/swift/ABI/MetadataKind.def
-  // 0x201 = MetadataKind::Enum
-  // 0x202 = MetadataKind::Optional
-  // 0x301 = MetadataKind::Tuple
-  // 0x303 = MetadataKind::Existential
   static var enumeration: Self { .init(rawValue: 0x201) }
   static var optional: Self { .init(rawValue: 0x202) }
   static var tuple: Self { .init(rawValue: 0x301) }
   static var existential: Self { .init(rawValue: 0x303) }
 }
 
-// MARK: -
-
 private struct EnumMetadata: Metadata {
   let ptr: UnsafeRawPointer
 
   init(assumingEnum type: Any.Type) {
-    ptr = unsafeBitCast(type, to: UnsafeRawPointer.self)
+    self.ptr = unsafeBitCast(type, to: UnsafeRawPointer.self)
   }
 
   init?(_ type: Any.Type) {
     self.init(assumingEnum: type)
-    guard kind == .enumeration || kind == .optional else { return nil }
+    guard self.kind == .enumeration || self.kind == .optional else { return nil }
   }
 
   var genericArguments: GenericArgumentVector? {
     guard typeDescriptor.flags.contains(.isGeneric) else { return nil }
-    return .init(ptr: ptr.advanced(by: 2 * pointerSize))
+    return .init(ptr: self.ptr.advanced(by: 2 * pointerSize))
   }
 
   var typeDescriptor: EnumTypeDescriptor {
-    return EnumTypeDescriptor(
-      ptr: ptr.advanced(by: pointerSize).load(as: UnsafeRawPointer.self))
+    EnumTypeDescriptor(
+      ptr: self.ptr.load(fromByteOffset: pointerSize, as: UnsafeRawPointer.self)
+    )
   }
 
   func tag<Enum>(of value: Enum) -> UInt32 {
-    return withUnsafePointer(to: value) {
-      valueWitnessTable.getEnumTag($0, self.ptr)
+    withUnsafePointer(to: value) {
+      self.valueWitnessTable.getEnumTag($0, self.ptr)
     }
   }
 }
@@ -415,13 +268,13 @@ private struct EnumMetadata: Metadata {
 extension EnumMetadata {
   func associatedValueType(forTag tag: UInt32) -> Any.Type {
     guard
-      let typeName = typeDescriptor.fieldDescriptor?.field(atIndex: tag).typeName,
+      let typeName = self.typeDescriptor.fieldDescriptor?.field(atIndex: tag).typeName,
       let type = swift_getTypeByMangledNameInContext(
         typeName.ptr, typeName.length,
-        genericContext: typeDescriptor.ptr,
-        genericArguments: genericArguments?.ptr)
+        genericContext: self.typeDescriptor.ptr,
+        genericArguments: self.genericArguments?.ptr
+      )
     else {
-      // There's not really a good answer for this. Void is a safe answer since it's zero-size.
       return Void.self
     }
 
@@ -440,11 +293,11 @@ private func swift_getTypeByMangledNameInContext(
 
 extension EnumMetadata {
   func destructivelyProjectPayload(of value: UnsafeMutableRawPointer) {
-    valueWitnessTable.destructiveProjectEnumData(value, ptr)
+    self.valueWitnessTable.destructiveProjectEnumData(value, ptr)
   }
 
   func destructivelyInjectTag(_ tag: UInt32, intoPayload payload: UnsafeMutableRawPointer) {
-    valueWitnessTable.destructiveInjectEnumData(payload, tag, ptr)
+    self.valueWitnessTable.destructiveInjectEnumData(payload, tag, ptr)
   }
 }
 
@@ -453,19 +306,18 @@ extension EnumMetadata {
 private struct EnumTypeDescriptor {
   let ptr: UnsafeRawPointer
 
-  var flags: Flags { Flags(rawValue: ptr.load(as: UInt32.self)) }
+  var flags: Flags { Flags(rawValue: self.ptr.load(as: UInt32.self)) }
 
   var fieldDescriptor: FieldDescriptor? {
-    return
-      ptr
+    self.ptr
       .advanced(by: 4 * 4)
       .loadRelativePointer()
       .map(FieldDescriptor.init)
   }
 
-  var payloadCaseCount: UInt32 { ptr.advanced(by: 5 * 4).load(as: UInt32.self) & 0xffffff }
+  var payloadCaseCount: UInt32 { self.ptr.load(fromByteOffset: 5 * 4, as: UInt32.self) & 0xFFFFFF }
 
-  var emptyCaseCount: UInt32 { ptr.advanced(by: 6 * 4).load(as: UInt32.self) }
+  var emptyCaseCount: UInt32 { self.ptr.load(fromByteOffset: 6 * 4, as: UInt32.self) }
 }
 
 extension EnumTypeDescriptor {
@@ -482,33 +334,32 @@ private struct TupleMetadata: Metadata {
   let ptr: UnsafeRawPointer
 
   init?(_ type: Any.Type) {
-    ptr = unsafeBitCast(type, to: UnsafeRawPointer.self)
-    guard kind == .tuple else { return nil }
+    self.ptr = unsafeBitCast(type, to: UnsafeRawPointer.self)
+    guard self.kind == .tuple else { return nil }
   }
 
   var elementCount: UInt {
-    return
-      ptr
+    self.ptr
       .advanced(by: pointerSize)  // kind
       .load(as: UInt.self)
   }
 
   var labels: UnsafePointer<UInt8>? {
-    return
-      ptr
+    self.ptr
       .advanced(by: pointerSize)  // kind
       .advanced(by: pointerSize)  // elementCount
       .load(as: UnsafePointer<UInt8>?.self)
   }
 
   func element(at i: Int) -> Element {
-    return Element(
+    Element(
       ptr:
-        ptr
+        self.ptr
         .advanced(by: pointerSize)  // kind
         .advanced(by: pointerSize)  // elementCount
         .advanced(by: pointerSize)  // labels pointer
-        .advanced(by: i * 2 * pointerSize))
+        .advanced(by: i * 2 * pointerSize)
+    )
   }
 }
 
@@ -516,19 +367,20 @@ extension TupleMetadata {
   struct Element: Equatable {
     let ptr: UnsafeRawPointer
 
-    var type: Any.Type { ptr.load(as: Any.Type.self) }
-    var offset: UInt { ptr.advanced(by: pointerSize).load(as: UInt.self) }
+    var type: Any.Type { self.ptr.load(as: Any.Type.self) }
+
+    var offset: UInt { self.ptr.load(fromByteOffset: pointerSize, as: UInt.self) }
 
     static func == (lhs: Element, rhs: Element) -> Bool {
-      return lhs.type == rhs.type && lhs.offset == rhs.offset
+      lhs.type == rhs.type && lhs.offset == rhs.offset
     }
   }
 }
 
 extension TupleMetadata {
   func hasSameLayout(as other: TupleMetadata) -> Bool {
-    return self.elementCount == other.elementCount
-      && (0..<Int(elementCount)).allSatisfy { self.element(at: $0) == other.element(at: $0) }
+    self.elementCount == other.elementCount
+      && (0..<Int(self.elementCount)).allSatisfy { self.element(at: $0) == other.element(at: $0) }
   }
 }
 
@@ -538,33 +390,31 @@ private struct ExistentialMetadata: Metadata {
   let ptr: UnsafeRawPointer
 
   init?(_ type: Any.Type?) {
-    ptr = unsafeBitCast(type, to: UnsafeRawPointer.self)
-    guard kind == .existential else { return nil }
+    self.ptr = unsafeBitCast(type, to: UnsafeRawPointer.self)
+    guard self.kind == .existential else { return nil }
   }
 }
-
-// MARK: -
 
 private struct FieldDescriptor {
   let ptr: UnsafeRawPointer
 
   /// The size of a FieldRecord as stored in the executable.
-  var recordSize: Int { Int(ptr.advanced(by: 2 * 4 + 2).load(as: UInt16.self)) }
+  var recordSize: Int { Int(self.ptr.advanced(by: 2 * 4 + 2).load(as: UInt16.self)) }
 
   func field(atIndex i: UInt32) -> FieldRecord {
-    return FieldRecord(
-      ptr: ptr.advanced(by: 2 * 4 + 2 * 2 + 4).advanced(by: Int(i) * recordSize))
+    FieldRecord(
+      ptr: self.ptr.advanced(by: 2 * 4 + 2 * 2 + 4).advanced(by: Int(i) * recordSize)
+    )
   }
 }
 
 private struct FieldRecord {
   let ptr: UnsafeRawPointer
 
-  var flags: Flags { Flags(rawValue: ptr.load(as: UInt32.self)) }
+  var flags: Flags { Flags(rawValue: self.ptr.load(as: UInt32.self)) }
 
   var typeName: MangledTypeName? {
-    return
-      ptr
+    self.ptr
       .advanced(by: 4)
       .loadRelativePointer()
       .map { MangledTypeName(ptr: $0.assumingMemoryBound(to: UInt8.self)) }
@@ -583,44 +433,38 @@ private struct MangledTypeName {
   let ptr: UnsafePointer<UInt8>
 
   var length: UInt {
-    // Type name mangling is described here:
     // https://github.com/apple/swift/blob/main/docs/ABI/Mangling.rst
-    // Since a mangled name can contain NUL bytes, I can't just use `strlen` or equivalent.
-
-    var p = ptr
+    var ptr = self.ptr
     while true {
-      switch p.pointee {
+      switch ptr.pointee {
       case 0:
-        return UInt(bitPattern: p - ptr)
+        return UInt(bitPattern: ptr - self.ptr)
       case 0x01...0x17:
-        // Relative symbolic reference.
-        p = p.advanced(by: 5)
+        // Relative symbolic reference
+        ptr = ptr.advanced(by: 5)
       case 0x18...0x1f:
         // Absolute symbolic reference
-        p = p.advanced(by: 1 + pointerSize)
+        ptr = ptr.advanced(by: 1 + pointerSize)
       default:
-        // Just a humble character.
-        p = p.advanced(by: 1)
+        ptr = ptr.advanced(by: 1)
       }
     }
   }
 }
-
-// MARK: -
 
 private struct ValueWitnessTable {
   let ptr: UnsafeRawPointer
 
   var getEnumTag: @convention(c) (_ value: UnsafeRawPointer, _ metadata: UnsafeRawPointer) -> UInt32
   {
-    return ptr.advanced(by: 10 * pointerSize + 2 * 4).loadInferredType()
+    self.ptr.advanced(by: 10 * pointerSize + 2 * 4).loadInferredType()
   }
 
   // This witness transforms an enum value into its associated value, in place.
   var destructiveProjectEnumData:
     @convention(c) (_ value: UnsafeMutableRawPointer, _ metadata: UnsafeRawPointer) -> Void
   {
-    return ptr.advanced(by: 11 * pointerSize + 2 * 4).loadInferredType()
+    self.ptr.advanced(by: 11 * pointerSize + 2 * 4).loadInferredType()
   }
 
   // This witness transforms an associated value into its enum value, in place.
@@ -628,21 +472,17 @@ private struct ValueWitnessTable {
     @convention(c) (_ value: UnsafeMutableRawPointer, _ tag: UInt32, _ metadata: UnsafeRawPointer)
       -> Void
   {
-    return ptr.advanced(by: 12 * pointerSize + 2 * 4).loadInferredType()
+    self.ptr.advanced(by: 12 * pointerSize + 2 * 4).loadInferredType()
   }
 }
-
-// MARK: -
 
 private struct GenericArgumentVector {
   let ptr: UnsafeRawPointer
 }
 
-// MARK: -
-
 extension UnsafeRawPointer {
   fileprivate func loadInferredType<Type>() -> Type {
-    return load(as: Type.self)
+    self.load(as: Type.self)
   }
 
   fileprivate func loadRelativePointer() -> UnsafeRawPointer? {

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -94,7 +94,7 @@ public func extract<Root, Value>(_ embed: @escaping (Value) -> Root) -> (Root) -
     cachedTag = embedTag
     cachedStrategy = Strategy<Root, Value>(tag: embedTag)
 
-    guard cachedTag == rootTag else { return nil }
+    guard embedTag == rootTag else { return nil }
 
     return value
   }

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -70,7 +70,10 @@ public func extract<Root, Value>(_ embed: @escaping (Value) -> Root) -> (Root) -
   guard
     let metadata = EnumMetadata(Root.self),
     metadata.typeDescriptor.fieldDescriptor != nil
-  else { return { _ in nil } }
+  else {
+    assertionFailure("embed parameter must be a valid enum case initializer")
+    return { _ in nil }
+  }
 
   var cachedTag: UInt32?
   var cachedStrategy: Strategy<Root, Value>?

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -137,17 +137,16 @@ extension Strategy {
       // Workaround for https://bugs.swift.org/browse/SR-12044
       self = .void
 
-    } else if
+    } else if let avMetadata = TupleMetadata(avType), avMetadata.elementCount == 1 {
       // Drop payload label from metadata, e.g., treat `(foo: Foo)` as `Foo`.
-      let avMetadata = TupleMetadata(avType), avMetadata.elementCount == 1 {
       self.init(tag: tag, assumedAssociatedValueType: avMetadata.element(at: 0).type)
 
     } else if
-      // Drop payload labels from metadata, e.g., treat `(foo: Foo, bar: Bar)` as `(Foo, Bar)`.
       let avMetadata = TupleMetadata(avType),
       let valueMetadata = TupleMetadata(Value.self),
       valueMetadata.labels == nil
     {
+      // Drop payload labels from metadata, e.g., treat `(foo: Foo, bar: Bar)` as `(Foo, Bar)`.
       guard avMetadata.hasSameLayout(as: valueMetadata) else {
         self = .unimplemented
         return

--- a/Sources/CasePaths/Operators.swift
+++ b/Sources/CasePaths/Operators.swift
@@ -115,7 +115,7 @@ extension CasePath {
     lhs: CasePath,
     rhs: CasePath<Value, AppendedValue>
   ) -> CasePath<Root, AppendedValue> {
-    return lhs.appending(path: rhs)
+    lhs.appending(path: rhs)
   }
 
   /// Returns a new case path created by appending the given embed function.

--- a/Sources/swift-case-paths-benchmark/main.swift
+++ b/Sources/swift-case-paths-benchmark/main.swift
@@ -26,6 +26,10 @@ let success = BenchmarkSuite(name: "Success") {
   $0.benchmark("Reflection") {
     precondition(reflection.extract(from: enumCase) == 42)
   }
+
+  $0.benchmark("Reflection (uncached)") {
+    precondition((/Enum.associatedValue).extract(from: enumCase) == 42)
+  }
 }
 
 let failure = BenchmarkSuite(name: "Failure") {
@@ -35,6 +39,10 @@ let failure = BenchmarkSuite(name: "Failure") {
 
   $0.benchmark("Reflection") {
     precondition(reflection.extract(from: anotherCase) == nil)
+  }
+
+  $0.benchmark("Reflection (uncached)") {
+    precondition((/Enum.associatedValue).extract(from: anotherCase) == nil)
   }
 }
 

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -210,15 +210,17 @@ final class CasePathsTests: XCTestCase {
     }
   }
 
-  func testNonEnumExtract() {
-    // This is a bogus CasePath, intended to verify that it just returns nil.
-    let path: CasePath<Int, Int> = /{ $0 }
+  #if RELEASE
+    func testNonEnumExtract() {
+      // This is a bogus CasePath, intended to verify that it just returns nil.
+      let path: CasePath<Int, Int> = /{ $0 }
 
-    for _ in 1...2 {
-      let actual = path.extract(from: 42)
-      XCTAssertNil(actual)
+      for _ in 1...2 {
+        let actual = path.extract(from: 42)
+        XCTAssertNil(actual)
+      }
     }
-  }
+  #endif
 
   func testOptionalPayload() {
     enum Enum { case int(Int?) }

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -28,9 +28,8 @@ final class CasePathsTests: XCTestCase {
     }
   }
 
-  #if compiler(<5.3)
-    // This test crashes Xcode 11.7's compiler.
-  #else
+  // This test crashes Xcode 11.7's compiler.
+  #if compiler(>=5.3)
     func testSimpleOverloadedPayload() {
       enum Enum {
         case payload(a: Int)
@@ -381,7 +380,8 @@ final class CasePathsTests: XCTestCase {
       static let iitCase = Enum.indirectTuple(label: 100)
     }
 
-    // This is intentionally too big to fit in the three-word buffer of a protocol existential, so that it is stored indirectly.
+    // This is intentionally too big to fit in the three-word buffer of a protocol existential, so
+    // that it is stored indirectly.
     struct Conformer: TestProtocol, Equatable {
       var a, b, c, d: Int
       init() {
@@ -439,7 +439,8 @@ final class CasePathsTests: XCTestCase {
       case c(TestProtocol, Int)
     }
 
-    // The library doesn't handle this crazy esoteric case, but it detects it and returns nil instead of garbage.
+    // The library doesn't handle this crazy esoteric case, but it detects it and returns nil
+    // instead of garbage.
     let path: CasePath<Enum, (Int, Int)> = /Enum.c
 
     for _ in 1...2 {
@@ -600,7 +601,9 @@ final class CasePathsTests: XCTestCase {
   }
 
   func testCompoundUninhabitedType() {
-    // Under Swift 5.1 (Xcode 11.3), this test creates a bogus instance of the tuple `(Never, Never)`, but remarkably, doesn't cause a crash and extracts the correct answer (nil).
+    // Under Swift 5.1 (Xcode 11.3), this test creates a bogus instance of the tuple
+    // `(Never, Never)`, but remarkably, doesn't cause a crash and extracts the correct answer
+    // (`nil`).
 
     enum Enum {
       case nevers(Never, Never)


### PR DESCRIPTION
This does some stylistic cleanup from @mayoff's excellent PR, #37.

- Prefer implicit `return`
- Prefer explicit `self`
- Minimize comments. @mayoff's literate style was very helpful in getting an understanding of some of the code, and will live in the history of the project. We can consider bringing back context in the future if we find any of it helpful, but let's minimize comments for now.

@mayoff If you're cool with this, lemme know and I'll merge! A quick once-over to make sure I didn't break anything or make any incorrect assumptions would be helpful. All the tests appear to still pass.