### PR TITLE
fix issue #40 (case initializer promoted to return Optional)

### DIFF
--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -321,7 +321,7 @@ extension EnumMetadata {
   }
 
   func isOptional() -> Bool {
-    // All Optional types shared a common EnumTypeDescriptor.
+    // All Optional types share a common EnumTypeDescriptor.
     let optionalTypeDescriptor = EnumMetadata(assumingEnum: Void?.self).typeDescriptor
     return typeDescriptor == optionalTypeDescriptor
   }

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -162,11 +162,6 @@ extension Strategy {
       }
       self.init(tag: tag, assumedAssociatedValueType: Value.self)
 
-    } else if metadata.wrappedTypeIfOptional() == avType {
-      // Enum == Optional<Inner>
-      //
-      self = .unimplemented
-
     } else if ExistentialMetadata(avType) != nil {
       // Convert protocol existentials to `Any` so that they can be cast (`as? Value`).
       let anyStrategy = Strategy<Enum, Any>(nonExistentialTag: tag)

--- a/Sources/CasePaths/Operators.swift
+++ b/Sources/CasePaths/Operators.swift
@@ -26,6 +26,12 @@ public prefix func / <Root, Value>(
   .case(embed)
 }
 
+public prefix func / <Root, Value>(
+  embed: @escaping (Value) -> Root?
+) -> CasePath<Root?, Value> {
+  .optionalCase(embed)
+}
+
 /// Returns a void case path for a case with no associated value.
 ///
 /// - Note: This operator is only intended to be used with enum cases that have no associated

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -450,7 +450,6 @@ final class CasePathsTests: XCTestCase {
     }
   }
 
-  #if !DEBUG
   func testDirectExtractFromOptionalRoot() {
     // https://github.com/pointfreeco/swift-case-paths/issues/40
 
@@ -460,10 +459,9 @@ final class CasePathsTests: XCTestCase {
     }
 
     let root: Authentication? = .authenticated(token: "deadbeef")
-    // The following statement asserts in a DEBUG build.
-    let actual = extract(case: Authentication.authenticated, from: root)
-    // The “correct” answer is "deadbeef", but it's too hard to implement.
-    XCTAssertNil(actual)
+    let embed: (String) -> Authentication? = Authentication.authenticated
+    let actual = extract(case: embed, from: root)
+    XCTAssertEqual(actual, "deadbeef")
   }
 
   func testPathExtractFromOptionalRoot() {
@@ -475,12 +473,12 @@ final class CasePathsTests: XCTestCase {
     }
 
     let root: Authentication? = .authenticated(token: "deadbeef")
-    // The following statement asserts in a DEBUG build.
-    let actual = (/Authentication.authenticated).extract(from: root)
-    // The “correct” answer is "deadbeef", but it's too hard to implement.
-    XCTAssertNil(actual)
+    let path: CasePath<Authentication?, String> = /Authentication.authenticated
+    for _ in 1...2 {
+      let actual = path.extract(from: root)
+      XCTAssertEqual(actual, "deadbeef")
+    }
   }
-  #endif
 
   func testEmbed() {
     enum Foo: Equatable { case bar(Int) }

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -830,4 +830,61 @@ final class CasePathsTests: XCTestCase {
       "CasePath<Result<String, Error>, String>"
     )
   }
+
+  func testExtractFromOptionalRoot() {
+    enum Foo {
+      case foo(String)
+      case bar(String)
+      case baz
+    }
+
+    var opt: Foo? = .foo("blob1")
+    XCTAssertEqual("blob1", (/Foo.foo).extract(from: opt))
+    XCTAssertNil((/Foo.bar).extract(from: opt))
+    XCTAssertNil((/Foo.baz).extract(from: opt))
+
+    opt = .bar("blob2")
+    XCTAssertNil((/Foo.foo).extract(from: opt))
+    XCTAssertEqual("blob2", (/Foo.bar).extract(from: opt))
+    XCTAssertNil((/Foo.baz).extract(from: opt))
+
+    opt = .baz
+    XCTAssertNil((/Foo.foo).extract(from: opt))
+    XCTAssertNil((/Foo.bar).extract(from: opt))
+    XCTAssertNotNil((/Foo.baz).extract(from: opt))
+
+    opt = nil
+    XCTAssertNil((/Foo.foo).extract(from: opt))
+    XCTAssertNil((/Foo.bar).extract(from: opt))
+    XCTAssertNil((/Foo.baz).extract(from: opt))
+  }
+
+  func testExtractFromOptionalRootWithEmbeddedTagBits() {
+    enum E {
+      case c1(TestObject)
+      case c2(TestObject)
+    }
+
+    let o = TestObject()
+    let c1Path: CasePath<E?, TestObject> = /E.c1
+    let c2Path: CasePath<E?, TestObject> = /E.c2
+
+    func check(_ path: CasePath<E?, TestObject>, _ input: E?, _ expected: TestObject?) {
+      let actual = path.extract(from: input)
+      XCTAssertEqual(actual, expected)
+    }
+
+    for _ in 1...2 {
+      check(c1Path, nil, nil)
+      check(c1Path, .c1(o), o)
+      check(c1Path, .c2(o), nil)
+      check(c2Path, nil, nil)
+      check(c2Path, .c1(o), nil)
+      check(c2Path, .c2(o), o)
+    }
+  }
+}
+
+fileprivate class TestObject: Equatable {
+  static func == (lhs: TestObject, rhs: TestObject) -> Bool { lhs === rhs }
 }

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -450,6 +450,38 @@ final class CasePathsTests: XCTestCase {
     }
   }
 
+  #if !DEBUG
+  func testDirectExtractFromOptionalRoot() {
+    // https://github.com/pointfreeco/swift-case-paths/issues/40
+
+    enum Authentication {
+      case authenticated(token: String)
+      case unauthenticated
+    }
+
+    let root: Authentication? = .authenticated(token: "deadbeef")
+    // The following statement asserts in a DEBUG build.
+    let actual = extract(case: Authentication.authenticated, from: root)
+    // The “correct” answer is "deadbeef", but it's too hard to implement.
+    XCTAssertNil(actual)
+  }
+
+  func testPathExtractFromOptionalRoot() {
+    // https://github.com/pointfreeco/swift-case-paths/issues/40
+
+    enum Authentication {
+      case authenticated(token: String)
+      case unauthenticated
+    }
+
+    let root: Authentication? = .authenticated(token: "deadbeef")
+    // The following statement asserts in a DEBUG build.
+    let actual = (/Authentication.authenticated).extract(from: root)
+    // The “correct” answer is "deadbeef", but it's too hard to implement.
+    XCTAssertNil(actual)
+  }
+  #endif
+
   func testEmbed() {
     enum Foo: Equatable { case bar(Int) }
 


### PR DESCRIPTION
Swift promotes (A) -> B to (A) -> B? if necessary to make a statement
type-check. This can lead to an enum case initializer being promoted and
making extract erroneously return nil. Fixing it is hard, so instead I'm
detecting the problem and asserting.

Fixes #40.