### PR TITLE
(#42) handle embed's argument being promoted out of Optional

### DIFF
--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -831,6 +831,15 @@ final class CasePathsTests: XCTestCase {
     )
   }
 
+  func testOptionalInsideResult() {
+    let result: Result<String?, Error> = .success("hello, world")
+    let path: CasePath<Result<String?, Error>, String> = /Result.success
+    let actual = path.extract(from: result)
+    XCTAssertEqual(
+      actual,
+      "hello, world")
+  }
+
   func testExtractFromOptionalRoot() {
     enum Foo {
       case foo(String)


### PR DESCRIPTION
Swift can promoted a function taking an Optional argument to a function
taking a non-Optional argument. For example, it can promote
`Result<String?, Error>.success` from
`(String?) -> Result<String?, Error>` to
`(String) -> Result<String?, Error>`.

This commit handles that scenario properly.

Fixes #42.