### PR TITLE
Fix optional prompt when extracting different case.

### DIFF
--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -286,7 +286,7 @@ extension Strategy {
       let anyStrategy = Strategy<Enum, Any>(nonExistentialTag: tag)
       self = .existential { anyStrategy.extract(from: $0, tag: tag) }
 
-    } else if EnumMetadata(avType)?.isOptional() ?? false {
+    } else if avType == Value?.self {
       // Handle contravariant optional demotion, e.g. embed function
       // `(String?) -> Result<String?, Error>)` interpreted as `(String) -> Result<String?, Error>`
       let wrappedStrategy = Strategy<Enum, Value?>(tag: tag, assumedAssociatedValueType: avType)
@@ -443,18 +443,6 @@ extension EnumMetadata {
 
   func destructivelyInjectTag(_ tag: UInt32, intoPayload payload: UnsafeMutableRawPointer) {
     self.valueWitnessTable.destructiveInjectEnumData(payload, tag, ptr)
-  }
-}
-
-extension EnumMetadata {
-  func wrappedTypeIfOptional() -> Any.Type? {
-    isOptional() ? genericArguments?.type(atIndex: 0) : nil
-  }
-
-  func isOptional() -> Bool {
-    // All Optional types share a common EnumTypeDescriptor.
-    let optionalTypeDescriptor = EnumMetadata(assumingEnum: Void?.self).typeDescriptor
-    return typeDescriptor == optionalTypeDescriptor
   }
 }
 

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -822,6 +822,8 @@ final class CasePathsTests: XCTestCase {
     XCTAssertEqual(
       actual,
       "hello, world")
+
+    XCTAssertNil((/Result.failure).extract(from: result))
   }
 
   func testExtractFromOptionalRoot() {
@@ -875,6 +877,21 @@ final class CasePathsTests: XCTestCase {
       check(c2Path, .c1(o), nil)
       check(c2Path, .c2(o), o)
     }
+  }
+
+  func testExtractionFailureOfOptional() {
+    enum Action {
+      case child1(Child1)
+      case child2(Child2?)
+    }
+    enum Child1 {
+      case a
+    }
+    enum Child2 {
+      case b
+    }
+
+    XCTAssertNil((/Action.child1).extract(from: .child2(.b)))
   }
 }
 


### PR DESCRIPTION
This fixes #45 and hopefully doesn't introduce new problems 😬. We were entering into an infinite loop when trying to extract a different case from an enum value that held an optional.

For example, trying to extract `/Result.failure` from a `Result<Int?, Error>` caused the case path to be promoted to `CasePath<Result<Int?, Error>, Error?>`, and then recursively promoted to `CasePath<Result<Int?, Error>, Error??>`, and then `CasePath<Result<Int?, Error>, Error???>`, etc...

/cc @mayoff 