### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run tests
         run: make test-swift
 
-  macos-10-5:
+  macos-10-15:
     name: MacOS 10.15
     runs-on: macos-10.15
     strategy:


### PR DESCRIPTION
Looks like "macOS-latest" refers to Big Sur now, which doesn't have 11.3. Dunno if there's a better way to share some of this YAML, but here goes.