### PR TITLE
Add Optional Kleisli composition function

### DIFF
--- a/Sources/CasePaths/Operators.swift
+++ b/Sources/CasePaths/Operators.swift
@@ -214,3 +214,18 @@ public func .. <Root, Value, AppendedValue>(
 ) -> (Root) -> AppendedValue? {
   return { root in lhs(root).flatMap((/rhs).extract(from:)) }
 }
+
+/// Returns a new extract function by appending the next extract function.
+/// Useful when composing optional-returning functions together.
+///
+/// - Parameters:
+///   - lhs: An extract function from a root to a value.
+///   - rhs: An extract function from a value other appended value.
+/// - Returns: A new extract function from the first extract function's root to the
+///   function's appended value.
+public func .. <Root, Value, AppendedValue>(
+  lhs: @escaping (Root) -> Value?,
+  rhs: @escaping (Value) -> AppendedValue?
+) -> (Root) -> AppendedValue? {
+  return { root in lhs(root).flatMap(rhs) }
+}


### PR DESCRIPTION
Hi Pointfree team 👋 

I came across with the composition usage of:

```swift
// 1. /RootAction.screen1: RootAction -> Screen1Action?
// 2. someTranslatorFunc: Screen1Action -> SomeOtherScreenAction?
reducer.pullback(action: /RootAction.screen1 .. someTranslatorFunc)
```

where `someTranslatorFunc` is an action-translation between 2 components which is NOT derived from enum case.

In this scenario, an ordinary Optional Kleisli composition becomes necessary (than the overload in Line 211), 
so I think it's worth adding it in this library.

What do you think?