### PR TITLE
Add AssociatedValueAccessible

### DIFF
--- a/Sources/CasePaths/AssociatedValueAccessible.swift
+++ b/Sources/CasePaths/AssociatedValueAccessible.swift
@@ -1,0 +1,28 @@
+/// Add this protocol to enum for access to it's associated values over subscription with CasePath.
+///
+/// ```swift
+/// enum Foo: AssociatedValueAccessible {
+///   case bar(Int)
+/// }
+///
+/// let foo = Foo.bar(42)
+/// let value = foo[/Foo.bar] // Optional<Int>(42)
+///
+/// var foo = Foo.bar(42)
+/// foo[/Foo.bar] = 84
+/// let value = foo[/Foo.bar] // Optional<Int>(84)
+/// ```
+public protocol AssociatedValueAccessible {}
+
+public extension AssociatedValueAccessible {
+  subscript<Value>(_ casePath: CasePath<Self, Value>) -> Value? {
+    get {
+      casePath.extract(from: self)
+    }
+    set {
+      if let value = newValue {
+        self = casePath.embed(value)
+      }
+    }
+  }
+}

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -949,6 +949,19 @@ final class CasePathsTests: XCTestCase {
     try (/Foo.bar).modify(&foo) { $0 *= 2 }
     XCTAssertEqual(foo, .bar(84))
   }
+
+  func testAccessWithSubscript() throws {
+    enum Foo: AssociatedValueAccessible { case bar(Int) }
+    let foo = Foo.bar(42)
+    XCTAssertEqual(foo[/Foo.bar], 42)
+  }
+
+  func testModifyWithSubscript() throws {
+    enum Foo: AssociatedValueAccessible { case bar(Int) }
+    var foo = Foo.bar(42)
+    foo[/Foo.bar] = 84
+    XCTAssertEqual(foo[/Foo.bar], 84)
+  }
 }
 
 private class TestObject: Equatable {


### PR DESCRIPTION
Hi!

I just added AssociatedValueAccessible protocol which allow more easily and convenience methods for get/set values over subscript with CasePath.

Example:

```swift
enum Foo: AssociatedValueAccessible {
   case bar(Int)
}

let foo = Foo.bar(42)
let value = foo[/Foo.bar] // Optional<Int>(42)

var foo = Foo.bar(42)
foo[/Foo.bar] = 84
let value = foo[/Foo.bar] // Optional<Int>(84)
```