### PR TITLE
Introduce IfCaseLetEmbed

### DIFF
--- a/Sources/CasePaths/CasePaths.swift
+++ b/Sources/CasePaths/CasePaths.swift
@@ -54,3 +54,29 @@ extension CasePath where Value: LosslessStringConvertible, Root == String {
     )
   }
 }
+
+extension CasePath {
+  /// Helper function for enum properies
+  ///
+  /// Usage
+  /// ```
+  /// enum Enum {
+  ///   case a(Int)
+  ///   case b(Bool)
+  ///
+  ///   var a: Int? {
+  ///     get { (/Self.a).extract(from: self) }
+  ///     set { (/Self.a).ifCaseLetEmbed(newValue, in: &self) }
+  ///   }
+  ///
+  ///   var b: Bool? {
+  ///     get { (/Self.b).extract(from: self) }
+  ///     set { (/Self.b).ifCaseLetEmbed(newValue, in: &self) }
+  ///   }
+  /// }
+  /// ```
+  public func ifCaseLetEmbed(_ value: Value?, in root: inout Root) {
+    guard extract(from: root) != nil, let value = value else { return }
+    root = embed(value)
+  }
+}


### PR DESCRIPTION
It enables you to implement enum properties easier

```swift
enum Enum {
  case a(Int)
  case b(Bool)
  
  var a: Int? {
    get { (/Self.a).extract(from: self) }
    set { (/Self.a).ifCaseLetEmbed(newValue, in: &self) }
  }
  
  var b: Bool? {
    get { (/Self.b).extract(from: self) }
    set { (/Self.b).ifCaseLetEmbed(newValue, in: &self) }
  }
}
```

instead of 

```swift
enum Enum {
  case a(Int)
  case b(Bool)
  
  var a: Int? {
    get { (/Self.a).extract(from: self) }
    set {
      guard case .a = self else { return }
      self = .a(newValue)
    }
  }
  
  var b: Bool? {
    get { (/Self.b).extract(from: self) }
    set {
      guard case .b = self else { return }
      self = .b(newValue)
    }
  }
}
```