### PR TITLE
Combine operator: extract

### DIFF
--- a/Sources/CasePaths/Combine.swift
+++ b/Sources/CasePaths/Combine.swift
@@ -1,0 +1,43 @@
+#if canImport(Combine)
+import Combine
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+extension Publishers {
+  public struct Extract<Upstream, Output>: Publisher where Upstream: Publisher {
+    public typealias Failure = Upstream.Failure
+
+    public let upstream: AnyPublisher<Output, Failure>
+
+    public init(upstream: Upstream, casePath: CasePath<Upstream.Output, Output>) {
+      self.upstream = upstream
+        .flatMap { upstreamValue -> AnyPublisher<Output, Failure> in
+          guard let extracted = casePath.extract(from: upstreamValue) else {
+            return Empty().eraseToAnyPublisher()
+          }
+          return Just(extracted).setFailureType(to: Failure.self).eraseToAnyPublisher()
+        }
+        .eraseToAnyPublisher()
+    }
+
+    public func receive<S>(subscriber: S) where S: Subscriber, Failure == S.Failure, Output == S.Input {
+      upstream.receive(subscriber: subscriber)
+    }
+  }
+}
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+extension Publisher {
+  /// Extract the enum associated value from an upstream.
+  ///
+  /// ```swift
+  /// Just(Result<Int, Error>.success(42)).extract(/Result.success) // Emits 42
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - casePath: A casePath to extract the value from.
+  /// - Returns: A new publisher emitting the extracted value from upstream enum value.
+  public func extract<V>(_ casePath: CasePath<Self.Output, V>) -> Publishers.Extract<Self, V> {
+    return Publishers.Extract(upstream: self, casePath: casePath)
+  }
+}
+#endif


### PR DESCRIPTION
Hi there!

I was wondering if you could be interested to integrate this Combine operator in the case-paths library.
We use it for a while now, and it's pretty helpful for making simple stream chains.

As an example in our usage :

```swift
imageService
      .loadImage(request)
      .filter(\.isSuccess)
      .extract(/AnyImage.FetchStatus.success)
      .eraseToAnyPublisher()
```

PS: I didn't implement any tests for now, it's just to see the interest : maybe you don't want any Combine code in this repository, but I think it's very complimentary with the library for Combine users.