### PR TITLE
Fix Linux reflection bug in tuple metadata alignment

### DIFF
--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -518,7 +518,7 @@ extension TupleMetadata {
 
     var type: Any.Type { self.ptr.load(as: Any.Type.self) }
 
-    var offset: UInt { self.ptr.load(fromByteOffset: pointerSize, as: UInt.self) }
+    var offset: UInt { self.ptr.load(fromByteOffset: pointerSize, as: UInt32.self) }
 
     static func == (lhs: Element, rhs: Element) -> Bool {
       lhs.type == rhs.type && lhs.offset == rhs.offset

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -518,7 +518,7 @@ extension TupleMetadata {
 
     var type: Any.Type { self.ptr.load(as: Any.Type.self) }
 
-    var offset: UInt { self.ptr.load(fromByteOffset: pointerSize, as: UInt32.self) }
+    var offset: UInt32 { self.ptr.load(fromByteOffset: pointerSize, as: UInt32.self) }
 
     static func == (lhs: Element, rhs: Element) -> Bool {
       lhs.type == rhs.type && lhs.offset == rhs.offset


### PR DESCRIPTION
We were seeing some strange extraction issues on Linux and it appears to be related to using `UInt` vs. `UInt32`.