### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Have you found a bug with Case Paths you'd like to share?
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+Give a clear and concise description of what the bug is.
+
+**To Reproduce**
+Zip up a project that reproduces the behavior and attach it by dragging it here.
+
+```swift
+// And/or enter code that reproduces the behavior here.
+
+```
+
+**Expected behavior**
+Give a clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment**
+  - swift-case-paths [e.g. 0.8.0]
+  - Xcode [e.g. 13.4]
+  - Swift [e.g. 5.6]
+  - OS: [e.g. iOS 15]
+
+**Additional context**
+Add any more context about the problem here.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,10 @@
+---
+name: Question
+about: Have a question about the Case Paths?
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Case Paths uses GitHub issues for bugs. For more general discussion and help, please use [GitHub Discussions](https://github.com/pointfreeco/swift-composable-architecture/discussions) or [the Swift forum](https://forums.swift.org/c/related-projects/swift-composable-architecture) first.


### PR DESCRIPTION
We were getting a lot of issues related to Xcode beta bugs that may have been discussions instead, due to lack of wayfinding. So here's a PR that mostly reproduces TCA's issue templates.

I've also opened a pinned issue (#81) that we'll hopefully be able to close soon 😪