### PR TITLE
Introduce initializer escape hatch for Xcode 14b1

### DIFF
--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -18,14 +18,16 @@ extension CasePath {
   public init<Wrapped>(_ embed: @escaping (Value) -> Root) where Root == Wrapped? {
     self.init(embed: embed, extract: optionalPromotedExtractHelp(embed))
   }
+}
 
+extension CasePath where Value == Void {
   /// Returns a void case path for a case with no associated value.
   ///
   /// - Note: This operator is only intended to be used with enum cases that have no associated
   ///   values. Its behavior is otherwise undefined.
   /// - Parameter root: A case with no an associated value.
   /// - Returns: A void case path.
-  public init(_ root: Root) where Value == Void {
+  public init(_ root: Root) {
     self.init(embed: { root }, extract: extractVoidHelp(root))
   }
 
@@ -35,18 +37,22 @@ extension CasePath {
   ///   values. Its behavior is otherwise undefined.
   /// - Parameter root: A case with no an associated value.
   /// - Returns: A void case path.
-  public init<Wrapped>(_ root: Root) where Root == Wrapped?, Value == Void {
+  public init<Wrapped>(_ root: Root) where Root == Wrapped? {
     self.init(embed: { root }, extract: optionalPromotedExtractVoidHelp(root))
   }
+}
 
+extension CasePath where Root == Value {
   /// Returns the identity case path for the given type. Enables `CasePath(MyType.self)` syntax.
   ///
   /// - Parameter type: A type for which to return the identity case path.
   /// - Returns: An identity case path.
-  public init(_ type: Root.Type) where Root == Value {
+  public init(_ type: Root.Type) {
     self = .self
   }
+}
 
+extension CasePath {
   /// Returns a case path that extracts values associated with a given enum case initializer.
   ///
   /// - Note: This function is only intended to be used with enum case initializers. Its behavior is

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -1,4 +1,52 @@
 extension CasePath {
+  /// Returns a case path for the given embed function.
+  ///
+  /// - Note: This operator is only intended to be used with enum cases that have no associated
+  ///   values. Its behavior is otherwise undefined.
+  /// - Parameter embed: An embed function.
+  /// - Returns: A case path.
+  public init(_ embed: @escaping (Value) -> Root) {
+    self.init(embed: embed, extract: extractHelp(embed))
+  }
+
+  /// Returns a case path for the given embed function.
+  ///
+  /// - Note: This operator is only intended to be used with enum cases that have no associated
+  ///   values. Its behavior is otherwise undefined.
+  /// - Parameter embed: An embed function.
+  /// - Returns: A case path.
+  public init<Wrapped>(_ embed: @escaping (Value) -> Root) where Root == Wrapped? {
+    self.init(embed: embed, extract: optionalPromotedExtractHelp(embed))
+  }
+
+  /// Returns a void case path for a case with no associated value.
+  ///
+  /// - Note: This operator is only intended to be used with enum cases that have no associated
+  ///   values. Its behavior is otherwise undefined.
+  /// - Parameter root: A case with no an associated value.
+  /// - Returns: A void case path.
+  public init(_ root: Root) where Value == Void {
+    self.init(embed: { root }, extract: extractVoidHelp(root))
+  }
+
+  /// Returns a void case path for a case with no associated value.
+  ///
+  /// - Note: This operator is only intended to be used with enum cases that have no associated
+  ///   values. Its behavior is otherwise undefined.
+  /// - Parameter root: A case with no an associated value.
+  /// - Returns: A void case path.
+  public init<Wrapped>(_ root: Root) where Root == Wrapped?, Value == Void {
+    self.init(embed: { root }, extract: optionalPromotedExtractVoidHelp(root))
+  }
+
+  /// Returns the identity case path for the given type. Enables `CasePath(MyType.self)` syntax.
+  ///
+  /// - Parameter type: A type for which to return the identity case path.
+  /// - Returns: An identity case path.
+  public init(_ type: Root.Type) where Root == Value {
+    self = .self
+  }
+
   /// Returns a case path that extracts values associated with a given enum case initializer.
   ///
   /// - Note: This function is only intended to be used with enum case initializers. Its behavior is


### PR DESCRIPTION
Workaround for highlighting/indentation issues mentioned in #81.

While we have a deprecated static `case` function we could un-deprecate, it doesn't read nicely when case paths needs to be appended, and the type needs to be fully-qualified:

```swift
CasePath.case(Action.response).appending(path: .case(Result.success))
^^^^     ^^^^
```

This PR introduces initializers that can be used instead of `/`.

```swift
CasePath(Action.response).appending(path: .init(Result.success))
```

Hopefully `/` will still be useful in the future, and these Xcode bugs are fixed quickly, but that doesn't mean we shouldn't provide an ergonomic solution in the meantime.
