### PR TITLE
Make CasePath sendable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - '*'
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   macos-11:
     name: MacOS 11

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,11 @@ test-linux:
 
 test-swift:
 	swift test \
+ 		--enable-test-discovery \
 		--parallel
 	swift test \
 	  -c release \
+ 		--enable-test-discovery \
 		--parallel
 
 format:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,9 @@ test-linux:
 
 test-swift:
 	swift test \
-		--enable-test-discovery \
+		--parallel
+	swift test \
+	  -c release \
 		--parallel
 
 format:

--- a/Sources/CasePaths/CasePath.swift
+++ b/Sources/CasePaths/CasePath.swift
@@ -78,7 +78,7 @@ public struct CasePath<Root, Value> {
   }
 }
 
-#if canImport(_Concurrency)
+#if canImport(_Concurrency) && compiler(>=5.5.2)
   extension CasePath: @unchecked Sendable {}
 #endif
 

--- a/Sources/CasePaths/CasePath.swift
+++ b/Sources/CasePaths/CasePath.swift
@@ -2,7 +2,7 @@
 /// value.
 ///
 /// This type defines key path-like semantics for enum cases.
-public struct CasePath<Root, Value> {
+public struct CasePath<Root, Value>: @unchecked Sendable {
   private let _embed: (Value) -> Root
   private let _extract: (Root) -> Value?
 

--- a/Sources/CasePaths/CasePath.swift
+++ b/Sources/CasePaths/CasePath.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// A path that supports embedding a value in a root and attempting to extract a root's embedded
 /// value.
 ///
@@ -11,9 +13,20 @@ public struct CasePath<Root, Value> {
   /// - Parameters:
   ///   - embed: A function that always succeeds in embedding a value in a root.
   ///   - extract: A function that can optionally fail in extracting a value from a root.
-  public init(embed: @escaping (Value) -> Root, extract: @escaping (Root) -> Value?) {
-    self._embed = embed
-    self._extract = extract
+  public init(
+    embed: @escaping (Value) -> Root,
+    extract: @escaping (Root) -> Value?
+  ) {
+    self._embed = {
+      lock.lock()
+      defer { lock.unlock() }
+      return embed($0)
+    }
+    self._extract = {
+      lock.lock()
+      defer { lock.unlock() }
+      return extract($0)
+    }
   }
 
   /// Returns a root by embedding a value.
@@ -76,3 +89,5 @@ extension CasePath: CustomStringConvertible {
 }
 
 struct ExtractionFailed: Error {}
+
+private let lock = NSRecursiveLock()

--- a/Sources/CasePaths/CasePath.swift
+++ b/Sources/CasePaths/CasePath.swift
@@ -78,7 +78,7 @@ public struct CasePath<Root, Value> {
   }
 }
 
-#if swift(>=5.5)
+#if canImport(_Concurrency)
   extension CasePath: @unchecked Sendable {}
 #endif
 

--- a/Sources/CasePaths/CasePath.swift
+++ b/Sources/CasePaths/CasePath.swift
@@ -2,7 +2,7 @@
 /// value.
 ///
 /// This type defines key path-like semantics for enum cases.
-public struct CasePath<Root, Value>: @unchecked Sendable {
+public struct CasePath<Root, Value> {
   private let _embed: (Value) -> Root
   private let _extract: (Root) -> Value?
 
@@ -64,6 +64,10 @@ public struct CasePath<Root, Value>: @unchecked Sendable {
     )
   }
 }
+
+#if swift(>=5.5)
+  extension CasePath: @unchecked Sendable {}
+#endif
 
 extension CasePath: CustomStringConvertible {
   public var description: String {

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -191,12 +191,8 @@ func extractHelp<Root, Value>(_ embed: @escaping (Value) -> Root) -> (Root) -> V
 
   var cachedTag: UInt32?
   var cachedStrategy: Strategy<Root, Value>?
-  let lock = NSLock()
 
   return { root in
-    lock.lock()
-    defer { lock.unlock() }
-
     let rootTag = metadata.tag(of: root)
 
     if let cachedTag = cachedTag, let cachedStrategy = cachedStrategy {
@@ -234,12 +230,8 @@ func optionalPromotedExtractHelp<Root, Value>(
 
   var cachedTag: UInt32?
   var cachedStrategy: Strategy<Root, Value>?
-  let lock = NSLock()
 
   return { optionalRoot in
-    lock.lock()
-    defer { lock.unlock() }
-
     guard let root = optionalRoot else { return nil }
 
     let rootTag = metadata.tag(of: root)

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -178,6 +178,8 @@ public func extract<Root, Value>(_ embed: @escaping (Value) -> Root?) -> (Root?)
 
 // MARK: - Extraction helpers
 
+import Foundation
+
 func extractHelp<Root, Value>(_ embed: @escaping (Value) -> Root) -> (Root) -> Value? {
   guard
     let metadata = EnumMetadata(Root.self),
@@ -189,8 +191,12 @@ func extractHelp<Root, Value>(_ embed: @escaping (Value) -> Root) -> (Root) -> V
 
   var cachedTag: UInt32?
   var cachedStrategy: Strategy<Root, Value>?
+  let lock = NSLock()
 
   return { root in
+    lock.lock()
+    defer { lock.unlock() }
+
     let rootTag = metadata.tag(of: root)
 
     if let cachedTag = cachedTag, let cachedStrategy = cachedStrategy {
@@ -228,8 +234,12 @@ func optionalPromotedExtractHelp<Root, Value>(
 
   var cachedTag: UInt32?
   var cachedStrategy: Strategy<Root, Value>?
+  let lock = NSLock()
 
   return { optionalRoot in
+    lock.lock()
+    defer { lock.unlock() }
+
     guard let root = optionalRoot else { return nil }
 
     let rootTag = metadata.tag(of: root)

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 extension CasePath {
   /// Returns a case path for the given embed function.
   ///
@@ -177,8 +179,6 @@ public func extract<Root, Value>(_ embed: @escaping (Value) -> Root?) -> (Root?)
 }
 
 // MARK: - Extraction helpers
-
-import Foundation
 
 func extractHelp<Root, Value>(_ embed: @escaping (Value) -> Root) -> (Root) -> Value? {
   guard

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 extension CasePath {
   /// Returns a case path for the given embed function.
   ///

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -1171,7 +1171,7 @@ final class CasePathsTests: XCTestCase {
     XCTAssertEqual(foo, .bar(84))
   }
 
-  func testSendable() async throws {
+  func testConcurrency() async throws {
     enum Enum { case payload(Int) }
     let root = Enum.payload(42)
     let casePath = /Enum.payload

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -1184,18 +1184,27 @@ final class CasePathsTests: XCTestCase {
 
       await withTaskGroup(of: Void.self) { group in
         for index in 1...iterationCount {
-          let casePath = CasePath<Enum, Int> {
+          let casePath1 = CasePath<Enum, Int> {
             count += 1
             return .payload($0)
           }
           group.addTask {
-            XCTAssertEqual(casePath.extract(from: Enum.payload(index)), index)
-            XCTAssertEqual(casePath.embed(index), .payload(index))
+            XCTAssertEqual(casePath1.extract(from: Enum.payload(index)), index)
+            XCTAssertEqual(casePath1.embed(index), .payload(index))
+          }
+
+          let casePath2 = CasePath<Enum, Int> {
+            count += 1
+            return .payload($0)
+          }
+          group.addTask {
+            XCTAssertEqual(casePath2.extract(from: Enum.payload(index)), index)
+            XCTAssertEqual(casePath2.embed(index), .payload(index))
           }
         }
       }
 
-      XCTAssertEqual(count, iterationCount * 2)
+      XCTAssertEqual(count, iterationCount * 4)
     }
   #endif
 }

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -1163,7 +1163,7 @@ final class CasePathsTests: XCTestCase {
     XCTAssertEqual(foo, .bar(84))
   }
 
-  #if canImport(_Concurrency)
+  #if canImport(_Concurrency) && compiler(>=5.5.2)
     func testConcurrency_SharedCasePath() async throws {
       enum Enum { case payload(Int) }
       let casePath = /Enum.payload

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -1163,7 +1163,7 @@ final class CasePathsTests: XCTestCase {
     XCTAssertEqual(foo, .bar(84))
   }
 
-  #if swift(>=5.5)
+  #if canImport(_Concurrency)
     func testConcurrency_SharedCasePath() async throws {
       enum Enum { case payload(Int) }
       let casePath = /Enum.payload

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -1164,7 +1164,7 @@ final class CasePathsTests: XCTestCase {
   }
 
   #if swift(>=5.5)
-    func testConcurrency() async throws {
+    func testConcurrency_SharedCasePath() async throws {
       enum Enum { case payload(Int) }
       let casePath = /Enum.payload
 

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -1171,19 +1171,21 @@ final class CasePathsTests: XCTestCase {
     XCTAssertEqual(foo, .bar(84))
   }
 
-  func testConcurrency() async throws {
-    enum Enum { case payload(Int) }
-    let root = Enum.payload(42)
-    let casePath = /Enum.payload
+  #if swift(>=5.5)
+    func testConcurrency() async throws {
+      enum Enum { case payload(Int) }
+      let root = Enum.payload(42)
+      let casePath = /Enum.payload
 
-    await withTaskGroup(of: Void.self) { group in
-      for _ in 1...10_000 {
-        group.addTask {
-          XCTAssertEqual(casePath.extract(from: root), 42)
+      await withTaskGroup(of: Void.self) { group in
+        for _ in 1...10_000 {
+          group.addTask {
+            XCTAssertEqual(casePath.extract(from: root), 42)
+          }
         }
       }
     }
-  }
+  #endif
 }
 
 private class TestObject: Equatable {

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -1170,6 +1170,20 @@ final class CasePathsTests: XCTestCase {
     try (/Foo.bar).modify(&foo) { $0 *= 2 }
     XCTAssertEqual(foo, .bar(84))
   }
+
+  func testSendable() async throws {
+    enum Enum { case payload(Int) }
+    let root = Enum.payload(42)
+    let casePath = /Enum.payload
+
+    await withTaskGroup(of: Void.self) { group in
+      for _ in 1...10_000 {
+        group.addTask {
+          XCTAssertEqual(casePath.extract(from: root), 42)
+        }
+      }
+    }
+  }
 }
 
 private class TestObject: Equatable {

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -1,16 +1,8 @@
 import CasePaths
 import XCTest
 
-// Replace this with XCTUnwrap when we drop support for Xcode 11.3.
-private func unwrap<Wrapped>(_ optional: Wrapped?) throws -> Wrapped {
-  guard let wrapped = optional else { throw UnexpectedNil() }
-  return wrapped
-}
-private struct UnexpectedNil: Error {}
-
 protocol TestProtocol {}
 extension Int: TestProtocol {}
-
 protocol TestClassProtocol: AnyObject {}
 
 final class CasePathsTests: XCTestCase {
@@ -1211,3 +1203,10 @@ final class CasePathsTests: XCTestCase {
 private class TestObject: Equatable {
   static func == (lhs: TestObject, rhs: TestObject) -> Bool { lhs === rhs }
 }
+
+// Replace this with XCTUnwrap when we drop support for Xcode 11.3.
+private func unwrap<Wrapped>(_ optional: Wrapped?) throws -> Wrapped {
+  guard let wrapped = optional else { throw UnexpectedNil() }
+  return wrapped
+}
+private struct UnexpectedNil: Error {}

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -1186,7 +1186,7 @@ final class CasePathsTests: XCTestCase {
     }
 
     func testConcurrency_NonSendableEmbed() async throws {
-      enum Enum { case payload(Int) }
+      enum Enum: Equatable { case payload(Int) }
       let iterationCount = 100_000
       var count = 0
 
@@ -1198,11 +1198,12 @@ final class CasePathsTests: XCTestCase {
           }
           group.addTask {
             XCTAssertEqual(casePath.extract(from: Enum.payload(index)), index)
+            XCTAssertEqual(casePath.embed(index), .payload(index))
           }
         }
       }
 
-      XCTAssertEqual(count, iterationCount)
+      XCTAssertEqual(count, iterationCount * 2)
     }
   #endif
 }


### PR DESCRIPTION
We can make `CasePath` sendable by locking around the part where we memoize some data from the runtime metadata. There's a chance we missed other parts that need locking, so feel free to let us know if you spot something!

Fixes #89