### PR TITLE
Add CasePath.some, for unwrapping optionals

### DIFF
--- a/Sources/CasePaths/CasePaths.swift
+++ b/Sources/CasePaths/CasePaths.swift
@@ -8,6 +8,13 @@ extension CasePath where Root == Value {
   }
 }
 
+extension CasePath where Root: _OptionalProtocol, Value == Root.Wrapped {
+  /// The optional case path: a case path that unwraps an optional value.
+  public static var some: CasePath {
+    .init(embed: Root.init, extract: { $0.optional })
+  }
+}
+
 extension CasePath where Root == Void {
   /// Returns a case path that always successfully extracts the given constant value.
   ///
@@ -53,4 +60,14 @@ extension CasePath where Value: LosslessStringConvertible, Root == String {
       extract: Value.init
     )
   }
+}
+
+public protocol _OptionalProtocol {
+  associatedtype Wrapped
+  var optional: Wrapped? { get }
+  init(_ some: Wrapped)
+}
+
+extension Optional: _OptionalProtocol {
+  public var optional: Wrapped? { self }
 }

--- a/Sources/CasePaths/Operators.swift
+++ b/Sources/CasePaths/Operators.swift
@@ -2,9 +2,11 @@ prefix operator /
 
 /// Returns whether or not a root value matches a particular case path.
 ///
-///     [Result<Int, Error>.success(1), .success(2), .failure(NSError()), .success(4)]
-///       .prefix(while: { /Result.success ~= $0 })
-///     // [.success(1), .success(2)]
+/// ```swift
+/// [Result<Int, Error>.success(1), .success(2), .failure(NSError()), .success(4)]
+///   .prefix(while: { /Result.success ~= $0 })
+/// // [.success(1), .success(2)]
+/// ```
 ///
 /// - Parameters:
 ///   - pattern: A case path.
@@ -73,14 +75,14 @@ public prefix func / <Root>(
 }
 
 /// Identifies and returns a given case path. Enables shorthand syntax on static case paths, _e.g._
-/// `/.self`  instead of `.self`.
+/// `/.self`  instead of `.self`, and `/.some` instead of `.some`.
 ///
-/// - Parameter type: A type for which to return the identity case path.
-/// - Returns: An identity case path.
-public prefix func / <Root>(
-  type: CasePath<Root, Root>
-) -> CasePath<Root, Root> {
-  .self
+/// - Parameter path: A case path to return.
+/// - Returns: The case path.
+public prefix func / <Root, Value>(
+  path: CasePath<Root, Value>
+) -> CasePath<Root, Value> {
+  path
 }
 
 /// Returns a function that can attempt to extract associated values from the given enum case

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -739,6 +739,13 @@ final class CasePathsTests: XCTestCase {
     )
   }
 
+  func testSome() {
+    XCTAssertEqual(
+      (/.some).extract(from: Optional(42)),
+      .some(42)
+    )
+  }
+
   func testLabeledCases() {
     enum Foo: Equatable {
       case bar(some: Int)


### PR DESCRIPTION
Enables shorthands `.some` and `/.some` for `/Optional.some`. This has come up in the past so it seems handy enough to ship.