### PR TITLE
Workaround for runtime returning wrong enum tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test-swift:
  		--enable-test-discovery \
 		--parallel
 	swift test \
-	  -c release \
+		-c release \
  		--enable-test-discovery \
 		--parallel
 

--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -464,7 +464,10 @@ private struct EnumMetadata: Metadata {
   }
 
   func tag<Enum>(of value: Enum) -> UInt32 {
-    withUnsafePointer(to: value) {
+    // NB: Workaround for https://github.com/apple/swift/issues/61708
+    guard self.typeDescriptor.emptyCaseCount + self.typeDescriptor.payloadCaseCount > 1
+    else { return 0 }
+    return withUnsafePointer(to: value) {
       self.valueWitnessTable.getEnumTag($0, self.ptr)
     }
   }

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -1170,6 +1170,25 @@ final class CasePathsTests: XCTestCase {
     XCTAssertEqual(foo, .bar(84))
   }
 
+  func testRegression_gh72() throws {
+    enum E1 {
+      case c1(E2)
+    }
+
+    enum E2 {
+      case c1(Bool)
+      case c2(Bool)
+      case c3(Any)
+    }
+
+    XCTAssertNotNil(
+      (/E1.c1).extract(from: .c1(.c1(true)))
+    )
+    XCTAssertNotNil(
+      (/E1.c1).extract(from: .c1(.c2(true)))
+    )
+  }
+
   #if canImport(_Concurrency) && compiler(>=5.5.2)
     func testConcurrency_SharedCasePath() async throws {
       enum Enum { case payload(Int) }


### PR DESCRIPTION
Fixes #72.

In release builds, Swift <=5.7 may return the wrong tag for single-case enums that nest another enum. We can work around this by always returning "0" as the tag for single case enums.