### PR TITLE
Reflection SPI

### DIFF
--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -476,7 +476,7 @@ private struct MetadataKind: Equatable {
 extension EnumMetadata {
   @_spi(Reflection) public func associatedValueType(forTag tag: UInt32) -> Any.Type {
     guard
-      let typeName = dump(self.typeDescriptor.fieldDescriptor)?.field(atIndex: tag).typeName,
+      let typeName = self.typeDescriptor.fieldDescriptor?.field(atIndex: tag).typeName,
       let type = swift_getTypeByMangledNameInContext(
         typeName.ptr, typeName.length,
         genericContext: self.typeDescriptor.ptr,


### PR DESCRIPTION
This PR begins to expose an SPI interface for some of the enum reflection machinery that was internal. We have a bunch of tools that recreate the `enumTag` functionality in each respective repo, but those libraries typically also depend on case paths, so it'd be simpler to get the functionality directly.