### PR TITLE
Introducing XCTModify

### DIFF
--- a/Sources/CasePaths/Internal/OpenExistential.swift
+++ b/Sources/CasePaths/Internal/OpenExistential.swift
@@ -1,0 +1,42 @@
+#if swift(>=5.7)
+  // MARK: swift(>=5.7)
+  // MARK: Equatable
+
+  func _isEqual(_ lhs: Any, _ rhs: Any) -> Bool? {
+    (lhs as? any Equatable)?.isEqual(other: rhs)
+  }
+
+  extension Equatable {
+    fileprivate func isEqual(other: Any) -> Bool {
+      self == other as? Self
+    }
+  }
+#else
+  // MARK: -
+  // MARK: swift(<5.7)
+
+  private enum Witness<T> {}
+
+  // MARK: Equatable
+
+  func _isEqual(_ lhs: Any, _ rhs: Any) -> Bool? {
+    func open<T>(_: T.Type) -> Bool? {
+      (Witness<T>.self as? AnyEquatable.Type)?.isEqual(lhs, rhs)
+    }
+    return _openExistential(type(of: lhs), do: open)
+  }
+
+  private protocol AnyEquatable {
+    static func isEqual(_ lhs: Any, _ rhs: Any) -> Bool
+  }
+
+  extension Witness: AnyEquatable where T: Equatable {
+    fileprivate static func isEqual(_ lhs: Any, _ rhs: Any) -> Bool {
+      guard
+        let lhs = lhs as? T,
+        let rhs = rhs as? T
+      else { return false }
+      return lhs == rhs
+    }
+  }
+#endif

--- a/Sources/CasePaths/XCTUnwrap.swift
+++ b/Sources/CasePaths/XCTUnwrap.swift
@@ -36,14 +36,14 @@ public func XCTUnwrap<Root, Case>(
 }
 
 public func XCTModify<Root, Case, Result>(
-  _ expression: @autoclosure () throws -> Root,
+  _ root: inout Root,
   case casePath: CasePath<Root, Case>,
   _ message: @autoclosure () -> String = "",
   file: StaticString = #file,
   line: UInt = #line,
   _ body: (inout Case) throws -> Result
 ) throws -> Result {
-  guard var value = try casePath.extract(from: expression())
+  guard var value = casePath.extract(from: root)
   else {
     #if canImport(ObjectiveC)
       _ = XCTCurrentTestCase?.perform(Selector(("setContinueAfterFailure:")), with: false)
@@ -68,8 +68,8 @@ public func XCTModify<Root, Case, Result>(
       """)
   }
 
+  root = casePath.embed(value)
   return result
 }
 
 private struct UnwrappingCase: Error {}
-

--- a/Tests/CasePathsTests/XCTModifyTests.swift
+++ b/Tests/CasePathsTests/XCTModifyTests.swift
@@ -11,8 +11,9 @@
           XCTModify failed: expected non-nil value of type "Int"
           """
       }
-      struct SomeError: Error {}
-      try XCTModify(Result<Int, Error>.failure(SomeError()), case: /Result.success) {
+
+      var result = Result<Int, Error>.failure(SomeError())
+      try XCTModify(&result, case: /Result.success) {
         $0 += 1
       }
     }
@@ -25,8 +26,9 @@
           XCTModify failed: expected non-nil value of type "Int"
           """
       }
-      struct SomeError: Error {}
-      try XCTModify(Optional(Result<Int, Error>.failure(SomeError())), case: /Result.success) {
+
+      var result = Optional(Result<Int, Error>.failure(SomeError()))
+      try XCTModify(&result, case: /Result.success) {
         $0 += 1
       }
     }
@@ -39,8 +41,9 @@
           XCTModify failed: expected non-nil value of type "Int"
           """
       }
-      struct SomeError: Error {}
-      try XCTModify(Optional<Result<Int, Error>>.none, case: /Result.success) {
+
+      var result = Optional<Result<Int, Error>>.none
+      try XCTModify(&result, case: /Result.success) {
         $0 += 1
       }
     }
@@ -54,10 +57,8 @@
           """
       }
 
-      struct SomeError: Error {}
-      try XCTModify(
-        Result<Int, Error>.failure(SomeError()), case: /Result.success, "Should be success"
-      ) {
+      var result = Result<Int, Error>.failure(SomeError())
+      try XCTModify(&result, case: /Result.success, "Should be success") {
         $0 += 1
       }
     }
@@ -65,25 +66,29 @@
     func testXCTModifyPass() throws {
       try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] != nil)
 
+      var result = Result<Int, SomeError>.success(2)
       XCTAssertEqual(
-        try XCTModify(Result<Int, Error>.success(2), case: /Result.success) {
+        try XCTModify(&result, case: /Result.success) {
           $0 += 1
           return $0
         },
         3
       )
+      XCTAssertEqual(result, .success(3))
     }
 
     func testXCTModifyPass_OptionalPromotion() throws {
       try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] != nil)
 
+      var result = Optional(Result<Int, SomeError>.success(2))
       XCTAssertEqual(
-        try XCTModify(Optional(Result<Int, Error>.success(2)), case: /Result.success) {
+        try XCTModify(&result, case: /Result.success) {
           $0 += 1
           return $0
         },
         3
       )
+      XCTAssertEqual(result, .success(3))
     }
 
     func testXCTModifyFailUnchangedEquatable() throws {
@@ -95,12 +100,16 @@
           """
       }
 
+      var result = Result<Int, SomeError>.success(2)
       XCTAssertEqual(
-        try XCTModify(Result<Int, Error>.success(2), case: /Result.success) {
+        try XCTModify(&result, case: /Result.success) {
           $0
         },
         2
       )
+      XCTAssertEqual(result, .success(2))
     }
   }
+
+  private struct SomeError: Error, Equatable {}
 #endif

--- a/Tests/CasePathsTests/XCTModifyTests.swift
+++ b/Tests/CasePathsTests/XCTModifyTests.swift
@@ -101,6 +101,22 @@
       }
       XCTAssertEqual(result, .success(2))
     }
+
+    func testXCTModify_BodyThrowsError() throws {
+      try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] != nil)
+
+      XCTExpectFailure {
+        $0.compactDescription == """
+          Threw error: SomeError()
+          """
+      }
+
+      var result = Result<Int, SomeError>.success(2)
+      XCTModify(&result, case: /Result.success) { _ in
+        throw SomeError()
+      }
+      XCTAssertEqual(result, .success(2))
+    }
   }
 
   private struct SomeError: Error, Equatable {}

--- a/Tests/CasePathsTests/XCTModifyTests.swift
+++ b/Tests/CasePathsTests/XCTModifyTests.swift
@@ -1,0 +1,106 @@
+#if DEBUG && (os(iOS) || os(macOS) || os(tvOS) || os(watchOS))
+  import CasePaths
+  import XCTest
+
+  final class XCTModifyTests: XCTestCase {
+    func testXCTModiftyFailure() throws {
+      try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] != nil)
+
+      XCTExpectFailure {
+        $0.compactDescription == """
+          XCTModify failed: expected non-nil value of type "Int"
+          """
+      }
+      struct SomeError: Error {}
+      try XCTModify(Result<Int, Error>.failure(SomeError()), case: /Result.success) {
+        $0 += 1
+      }
+    }
+
+    func testXCTModiftyFailure_OptionalPromotion() throws {
+      try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] != nil)
+
+      XCTExpectFailure {
+        $0.compactDescription == """
+          XCTModify failed: expected non-nil value of type "Int"
+          """
+      }
+      struct SomeError: Error {}
+      try XCTModify(Optional(Result<Int, Error>.failure(SomeError())), case: /Result.success) {
+        $0 += 1
+      }
+    }
+
+    func testXCTModiftyFailure_Nil_OptionalPromotion() throws {
+      try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] != nil)
+
+      XCTExpectFailure {
+        $0.compactDescription == """
+          XCTModify failed: expected non-nil value of type "Int"
+          """
+      }
+      struct SomeError: Error {}
+      try XCTModify(Optional<Result<Int, Error>>.none, case: /Result.success) {
+        $0 += 1
+      }
+    }
+
+    func testXCTModifyFailure_WithMessage() throws {
+      try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] != nil)
+
+      XCTExpectFailure {
+        $0.compactDescription == """
+          XCTModify failed: expected non-nil value of type "Int" - Should be success
+          """
+      }
+
+      struct SomeError: Error {}
+      try XCTModify(
+        Result<Int, Error>.failure(SomeError()), case: /Result.success, "Should be success"
+      ) {
+        $0 += 1
+      }
+    }
+
+    func testXCTModifyPass() throws {
+      try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] != nil)
+
+      XCTAssertEqual(
+        try XCTModify(Result<Int, Error>.success(2), case: /Result.success) {
+          $0 += 1
+          return $0
+        },
+        3
+      )
+    }
+
+    func testXCTModifyPass_OptionalPromotion() throws {
+      try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] != nil)
+
+      XCTAssertEqual(
+        try XCTModify(Optional(Result<Int, Error>.success(2)), case: /Result.success) {
+          $0 += 1
+          return $0
+        },
+        3
+      )
+    }
+
+    func testXCTModifyFailUnchangedEquatable() throws {
+      try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] != nil)
+
+      XCTExpectFailure {
+        $0.compactDescription == """
+          XCTModify failed: expected "Int" value to be modified but it was unchanged.
+          """
+      }
+
+      XCTAssertEqual(
+        try XCTModify(Result<Int, Error>.success(2), case: /Result.success) {
+          $0
+        },
+        2
+      )
+    }
+  }
+#endif

--- a/Tests/CasePathsTests/XCTModifyTests.swift
+++ b/Tests/CasePathsTests/XCTModifyTests.swift
@@ -8,12 +8,12 @@
 
       XCTExpectFailure {
         $0.compactDescription == """
-          XCTModify failed: expected non-nil value of type "Int"
+          XCTModify failed: expected to extract value of type "Int" from "Result<Int, Error>"
           """
       }
 
       var result = Result<Int, Error>.failure(SomeError())
-      try XCTModify(&result, case: /Result.success) {
+      XCTModify(&result, case: /Result.success) {
         $0 += 1
       }
     }
@@ -23,12 +23,13 @@
 
       XCTExpectFailure {
         $0.compactDescription == """
-          XCTModify failed: expected non-nil value of type "Int"
+          XCTModify failed: expected to extract value of type "Int" from \
+          "Optional<Result<Int, Error>>"
           """
       }
 
       var result = Optional(Result<Int, Error>.failure(SomeError()))
-      try XCTModify(&result, case: /Result.success) {
+      XCTModify(&result, case: /Result.success) {
         $0 += 1
       }
     }
@@ -38,12 +39,13 @@
 
       XCTExpectFailure {
         $0.compactDescription == """
-          XCTModify failed: expected non-nil value of type "Int"
+          XCTModify failed: expected to extract value of type "Int" from \
+          "Optional<Result<Int, Error>>"
           """
       }
 
       var result = Optional<Result<Int, Error>>.none
-      try XCTModify(&result, case: /Result.success) {
+      XCTModify(&result, case: /Result.success) {
         $0 += 1
       }
     }
@@ -53,12 +55,13 @@
 
       XCTExpectFailure {
         $0.compactDescription == """
-          XCTModify failed: expected non-nil value of type "Int" - Should be success
+          XCTModify failed: expected to extract value of type "Int" from "Result<Int, Error>" - \
+          Should be success
           """
       }
 
       var result = Result<Int, Error>.failure(SomeError())
-      try XCTModify(&result, case: /Result.success, "Should be success") {
+      XCTModify(&result, case: /Result.success, "Should be success") {
         $0 += 1
       }
     }
@@ -67,13 +70,9 @@
       try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] != nil)
 
       var result = Result<Int, SomeError>.success(2)
-      XCTAssertEqual(
-        try XCTModify(&result, case: /Result.success) {
-          $0 += 1
-          return $0
-        },
-        3
-      )
+      XCTModify(&result, case: /Result.success) {
+        $0 += 1
+      }
       XCTAssertEqual(result, .success(3))
     }
 
@@ -81,13 +80,9 @@
       try XCTSkipIf(ProcessInfo.processInfo.environment["CI"] != nil)
 
       var result = Optional(Result<Int, SomeError>.success(2))
-      XCTAssertEqual(
-        try XCTModify(&result, case: /Result.success) {
-          $0 += 1
-          return $0
-        },
-        3
-      )
+      XCTModify(&result, case: /Result.success) {
+        $0 += 1
+      }
       XCTAssertEqual(result, .success(3))
     }
 
@@ -101,12 +96,9 @@
       }
 
       var result = Result<Int, SomeError>.success(2)
-      XCTAssertEqual(
-        try XCTModify(&result, case: /Result.success) {
-          $0
-        },
-        2
-      )
+      XCTModify(&result, case: /Result.success) {
+        _ = $0
+      }
       XCTAssertEqual(result, .success(2))
     }
   }


### PR DESCRIPTION
This PR introduces a more streamlined way to perform an in-place mutation of a case in an enum when in a testing context:

```swift
try XCTModify(&result, case: /Result.success) {
  $0 += 1
}
```

You should think of `XCTModify` as a companion to `XCTUnwrap` as it allows you to safely unwrap a case from an enum, and then further apply a mutation. This helper will be very useful for the navigation tools being built for TCA.