### PR TITLE
Add reflection API for projecting into any enum value

### DIFF
--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -604,6 +604,20 @@ final class CasePathsTests: XCTestCase {
     XCTAssertEqual(CasePath(Authentication.authenticated).extract(from: root), "deadbeef")
   }
 
+  func testPathExtractFromOptionalRoot_AnyHashable() {
+    enum Authentication {
+      case authenticated(token: AnyHashable)
+      case unauthenticated
+    }
+
+    let root: Authentication? = .authenticated(token: "deadbeef")
+    let path: CasePath<Authentication?, String> = /Authentication.authenticated
+    for _ in 1...2 {
+      let actual = path.extract(from: root)
+      XCTAssertEqual(actual, "deadbeef")
+    }
+  }
+
   func testEmbed() {
     enum Foo: Equatable { case bar(Int) }
 

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -577,17 +577,15 @@ final class CasePathsTests: XCTestCase {
     XCTAssertEqual(itPath.extract(from: .citCase), .some(Conformer()))
   }
 
-  func testUnreasonableContravariantEmbed() {
+  func testCompoundContravariantEmbed() {
     enum Enum {
       case c(TestProtocol, Int)
     }
 
-    // The library doesn't handle this crazy esoteric case, but it detects it and returns nil
-    // instead of garbage.
     let path: CasePath<Enum, (Int, Int)> = /Enum.c
 
     for _ in 1...2 {
-      XCTAssertNil(path.extract(from: .c(34, 12)))
+      XCTAssert(try XCTUnwrap(path.extract(from: .c(34, 12))) == (34, 12))
     }
   }
 

--- a/Tests/CasePathsTests/ReflectionTests.swift
+++ b/Tests/CasePathsTests/ReflectionTests.swift
@@ -2,79 +2,81 @@
 import XCTest
 
 final class ReflectionTests: XCTestCase {
-  func testProject() throws {
-    struct MyIdentifiable: Identifiable {
-      let id = 42
-    }
-    let success = Result<MyIdentifiable, Error>.success(MyIdentifiable())
-    let anyIdentifiable = try XCTUnwrap(EnumMetadata.project(success) as? any Identifiable)
-    func id(of identifiable: some Identifiable) -> AnyHashable {
-      identifiable.id
-    }
-    XCTAssertEqual(42, id(of: anyIdentifiable))
-  }
-
-  func testProject_Existential() throws {
-    struct MyIdentifiable: Identifiable {
-      let id = 42
-    }
-    let success = Result<Any, Error>.success(MyIdentifiable())
-    let anyIdentifiable = try XCTUnwrap(EnumMetadata.project(success) as? any Identifiable)
-    func id(of identifiable: some Identifiable) -> AnyHashable {
-      identifiable.id
-    }
-    XCTAssertEqual(42, id(of: anyIdentifiable))
-  }
-
-  func testProject_Indirect() throws {
-    struct MyIdentifiable: Identifiable {
-      let id = 42
-    }
-    enum Enum {
-      indirect case indirectCase(MyIdentifiable)
-    }
-    let indirect = Enum.indirectCase(MyIdentifiable())
-    let anyIdentifiable = try XCTUnwrap(EnumMetadata.project(indirect) as? any Identifiable)
-    func id(of identifiable: some Identifiable) -> AnyHashable {
-      identifiable.id
-    }
-    XCTAssertEqual(42, id(of: anyIdentifiable))
-  }
-
-  func testProject_NoPayload() throws {
-    enum Enum {
-      case noPayload
-    }
-    let value = EnumMetadata.project(Enum.noPayload)
-    try XCTUnwrap(EnumMetadata.project(value) as? Void)
-  }
-
-  func testLabel() throws {
-    enum Enum: Equatable {
-      case label(id: Int)
-      case multiLabel(id: Int, name: String)
+  #if swift(>=5.7)
+    func testProject() throws {
+      struct MyIdentifiable: Identifiable {
+        let id = 42
+      }
+      let success = Result<MyIdentifiable, Error>.success(MyIdentifiable())
+      let anyIdentifiable = try XCTUnwrap(EnumMetadata.project(success) as? any Identifiable)
+      func id(of identifiable: some Identifiable) -> AnyHashable {
+        identifiable.id
+      }
+      XCTAssertEqual(42, id(of: anyIdentifiable))
     }
 
-    XCTAssertEqual(EnumMetadata.project(Enum.label(id: 42)) as? Int, 42)
-    let pair = try XCTUnwrap(
-      EnumMetadata.project(Enum.multiLabel(id: 42, name: "Blob")) as? (Int, String)
-    )
-    XCTAssert(pair == (42, "Blob"))
-  }
-
-  func testCompound() throws {
-    let object = Object()
-    enum Enum: Equatable {
-      indirect case indirect(Int, Object?, Int, Object?)
-      case direct(Int, Object?, Int, Object?)
+    func testProject_Existential() throws {
+      struct MyIdentifiable: Identifiable {
+        let id = 42
+      }
+      let success = Result<Any, Error>.success(MyIdentifiable())
+      let anyIdentifiable = try XCTUnwrap(EnumMetadata.project(success) as? any Identifiable)
+      func id(of identifiable: some Identifiable) -> AnyHashable {
+        identifiable.id
+      }
+      XCTAssertEqual(42, id(of: anyIdentifiable))
     }
 
-    let indirect = try XCTUnwrap(
-      EnumMetadata.project(Enum.indirect(42, nil, 43, object))
-        as? (Int, Object?, Int, Object?)
-    )
-    XCTAssert(indirect == (42, nil, 43, object))
-  }
+    func testProject_Indirect() throws {
+      struct MyIdentifiable: Identifiable {
+        let id = 42
+      }
+      enum Enum {
+        indirect case indirectCase(MyIdentifiable)
+      }
+      let indirect = Enum.indirectCase(MyIdentifiable())
+      let anyIdentifiable = try XCTUnwrap(EnumMetadata.project(indirect) as? any Identifiable)
+      func id(of identifiable: some Identifiable) -> AnyHashable {
+        identifiable.id
+      }
+      XCTAssertEqual(42, id(of: anyIdentifiable))
+    }
+
+    func testProject_NoPayload() throws {
+      enum Enum {
+        case noPayload
+      }
+      let value = EnumMetadata.project(Enum.noPayload)
+      try XCTUnwrap(EnumMetadata.project(value) as? Void)
+    }
+
+    func testLabel() throws {
+      enum Enum: Equatable {
+        case label(id: Int)
+        case multiLabel(id: Int, name: String)
+      }
+
+      XCTAssertEqual(EnumMetadata.project(Enum.label(id: 42)) as? Int, 42)
+      let pair = try XCTUnwrap(
+        EnumMetadata.project(Enum.multiLabel(id: 42, name: "Blob")) as? (Int, String)
+      )
+      XCTAssert(pair == (42, "Blob"))
+    }
+
+    func testCompound() throws {
+      let object = Object()
+      enum Enum: Equatable {
+        indirect case indirect(Int, Object?, Int, Object?)
+        case direct(Int, Object?, Int, Object?)
+      }
+
+      let indirect = try XCTUnwrap(
+        EnumMetadata.project(Enum.indirect(42, nil, 43, object))
+          as? (Int, Object?, Int, Object?)
+      )
+      XCTAssert(indirect == (42, nil, 43, object))
+    }
+  #endif
 }
 
 fileprivate class Object: Equatable {

--- a/Tests/CasePathsTests/ReflectionTests.swift
+++ b/Tests/CasePathsTests/ReflectionTests.swift
@@ -1,0 +1,51 @@
+@_spi(Reflection) import CasePaths
+import XCTest
+
+final class ReflectionTests: XCTestCase {
+  func testProject() throws {
+    struct MyIdentifiable: Identifiable {
+      let id = 42
+    }
+    let success = Result<MyIdentifiable, Error>.success(MyIdentifiable())
+    let anyIdentifiable = try XCTUnwrap(EnumMetadata.project(success) as? any Identifiable)
+    func id(of identifiable: some Identifiable) -> AnyHashable {
+      identifiable.id
+    }
+    XCTAssertEqual(42, id(of: anyIdentifiable))
+  }
+
+  func testProject_Existential() throws {
+    struct MyIdentifiable: Identifiable {
+      let id = 42
+    }
+    let success = Result<Any, Error>.success(MyIdentifiable())
+    let anyIdentifiable = try XCTUnwrap(EnumMetadata.project(success) as? any Identifiable)
+    func id(of identifiable: some Identifiable) -> AnyHashable {
+      identifiable.id
+    }
+    XCTAssertEqual(42, id(of: anyIdentifiable))
+  }
+
+  func testProject_Indirect() throws {
+    struct MyIdentifiable: Identifiable {
+      let id = 42
+    }
+    enum Enum {
+      indirect case indirectCase(MyIdentifiable)
+    }
+    let indirect = Enum.indirectCase(MyIdentifiable())
+    let anyIdentifiable = try XCTUnwrap(EnumMetadata.project(indirect) as? any Identifiable)
+    func id(of identifiable: some Identifiable) -> AnyHashable {
+      identifiable.id
+    }
+    XCTAssertEqual(42, id(of: anyIdentifiable))
+  }
+
+  func testProject_NoPayload() throws {
+    enum Enum {
+      case noPayload
+    }
+    let value = EnumMetadata.project(Enum.noPayload)
+    try XCTUnwrap(EnumMetadata.project(value) as? Void)
+  }
+}

--- a/Tests/CasePathsTests/ReflectionTests.swift
+++ b/Tests/CasePathsTests/ReflectionTests.swift
@@ -48,4 +48,24 @@ final class ReflectionTests: XCTestCase {
     let value = EnumMetadata.project(Enum.noPayload)
     try XCTUnwrap(EnumMetadata.project(value) as? Void)
   }
+
+  func testCompound() throws {
+    let object = Object()
+    enum Enum: Equatable {
+      indirect case indirect(Int, Object?, Int, Object?)
+      case direct(Int, Object?, Int, Object?)
+    }
+
+    let indirect = try XCTUnwrap(
+      EnumMetadata.project(Enum.indirect(42, nil, 43, object))
+        as? (Int, Object?, Int, Object?)
+    )
+    XCTAssert(indirect == (42, nil, 43, object))
+  }
+}
+
+fileprivate class Object: Equatable {
+  static func == (lhs: Object, rhs: Object) -> Bool {
+    return lhs === rhs
+  }
 }

--- a/Tests/CasePathsTests/ReflectionTests.swift
+++ b/Tests/CasePathsTests/ReflectionTests.swift
@@ -49,6 +49,19 @@ final class ReflectionTests: XCTestCase {
     try XCTUnwrap(EnumMetadata.project(value) as? Void)
   }
 
+  func testLabel() throws {
+    enum Enum: Equatable {
+      case label(id: Int)
+      case multiLabel(id: Int, name: String)
+    }
+
+    XCTAssertEqual(EnumMetadata.project(Enum.label(id: 42)) as? Int, 42)
+    let pair = try XCTUnwrap(
+      EnumMetadata.project(Enum.multiLabel(id: 42, name: "Blob")) as? (Int, String)
+    )
+    XCTAssert(pair == (42, "Blob"))
+  }
+
   func testCompound() throws {
     let object = Object()
     enum Enum: Equatable {


### PR DESCRIPTION
This PR reworks some of the extraction logic for case paths and exposes a `@_spi(Reflection)` helper for projecting the associated value of any enum into an existential `Any`. We can eliminate a bunch of work we're currently doing by always projecting into the field type described by the runtime and _then_ we can further attempt to cast to the extracted payload.

Fixes #83.

There are probably some performance improvements that can be made, but the benchmarks appear to perform as well as they do on `main`. 

/cc @mayoff