### PR TITLE
XCT{Unwrap,Modify}: Improve type name debugging

### DIFF
--- a/Sources/CasePaths/CasePath.swift
+++ b/Sources/CasePaths/CasePath.swift
@@ -84,7 +84,7 @@ public struct CasePath<Root, Value> {
 
 extension CasePath: CustomStringConvertible {
   public var description: String {
-    "CasePath<\(Root.self), \(Value.self)>"
+    "CasePath<\(typeName(Root.self)), \(typeName(Value.self))>"
   }
 }
 

--- a/Sources/CasePaths/Internal/TypeName.swift
+++ b/Sources/CasePaths/Internal/TypeName.swift
@@ -1,0 +1,46 @@
+// NB: This is adapted from Custom Dump and should ideally be kept in sync.
+func typeName(
+  _ type: Any.Type,
+  qualified: Bool = true,
+  genericsAbbreviated: Bool = false  // NB: This defaults to `true` in Custom Dump
+) -> String {
+  var name = _typeName(type, qualified: qualified)
+    .replacingOccurrences(
+      of: #"\(unknown context at \$[[:xdigit:]]+\)\."#,
+      with: "",
+      options: .regularExpression
+    )
+  for _ in 1...10 {  // NB: Only handle so much nesting
+    let abbreviated = name
+      .replacingOccurrences(
+        of: #"\bSwift.Optional<([^><]+)>"#,
+        with: "$1?",
+        options: .regularExpression
+      )
+      .replacingOccurrences(
+        of: #"\bSwift.Array<([^><]+)>"#,
+        with: "[$1]",
+        options: .regularExpression
+      )
+      .replacingOccurrences(
+        of: #"\bSwift.Dictionary<([^,<]+), ([^><]+)>"#,
+        with: "[$1: $2]",
+        options: .regularExpression
+      )
+    if abbreviated == name { break }
+    name = abbreviated
+  }
+  name = name.replacingOccurrences(
+    of: #"\w+\.([\w.]+)"#,
+    with: "$1",
+    options: .regularExpression
+  )
+  if genericsAbbreviated {
+    name = name.replacingOccurrences(
+      of: #"<.+>"#,
+      with: "",
+      options: .regularExpression
+    )
+  }
+  return name
+}

--- a/Sources/CasePaths/XCTUnwrap.swift
+++ b/Sources/CasePaths/XCTUnwrap.swift
@@ -24,7 +24,7 @@ public func XCTUnwrap<Root, Case>(
     let message = message()
     XCTFail(
       """
-      XCTUnwrap failed: expected non-nil value of type "\(Case.self)"\
+      XCTUnwrap failed: expected non-nil value of type "\(typeName(Case.self))"\
       \(message.isEmpty ? "" : " - " + message)
       """,
       file: file,
@@ -35,13 +35,20 @@ public func XCTUnwrap<Root, Case>(
   return value
 }
 
+/// Asserts that an enum value matches a particular case and modifies the associated value in place.
+///
+/// - Parameters:
+///   - root: An enum value.
+///   - casePath: A case path that can extract and embed the associated value of a particular case.
+///   - message: An optional description of a failure.
+///   - body: A closure that can modify the associated value of the given case.
 public func XCTModify<Root, Case>(
   _ root: inout Root,
   case casePath: CasePath<Root, Case>,
   _ message: @autoclosure () -> String = "",
+  _ body: (inout Case) throws -> Void,
   file: StaticString = #file,
-  line: UInt = #line,
-  _ body: (inout Case) throws -> Void
+  line: UInt = #line
 ) {
   guard var value = casePath.extract(from: root)
   else {
@@ -51,7 +58,8 @@ public func XCTModify<Root, Case>(
     let message = message()
     XCTFail(
       """
-      XCTModify failed: expected to extract value of type "\(Case.self)" from "\(Root.self)"\
+      XCTModify failed: expected to extract value of type "\(typeName(Case.self))" from \
+      "\(typeName(Root.self))"\
       \(message.isEmpty ? "" : " - " + message)
       """,
       file: file,
@@ -73,7 +81,7 @@ public func XCTModify<Root, Case>(
   {
     XCTFail(
       """
-      XCTModify failed: expected "\(Case.self)" value to be modified but it was unchanged.
+      XCTModify failed: expected "\(typeName(Case.self))" value to be modified but it was unchanged.
       """)
   }
 

--- a/Tests/CasePathsTests/XCTModifyTests.swift
+++ b/Tests/CasePathsTests/XCTModifyTests.swift
@@ -23,14 +23,14 @@
 
       XCTExpectFailure {
         $0.compactDescription == """
-          XCTModify failed: expected to extract value of type "Int" from \
-          "Optional<Result<Int, Error>>"
+          XCTModify failed: expected to extract value of type "Sheet.State" from \
+          "Destination.State?"
           """
       }
 
-      var result = Optional(Result<Int, Error>.failure(SomeError()))
-      XCTModify(&result, case: /Result.success) {
-        $0 += 1
+      var result = Optional(Destination.State.alert)
+      XCTModify(&result, case: /Destination.State.sheet) {
+        $0.count += 1
       }
     }
 
@@ -132,4 +132,16 @@
   }
 
   private struct SomeError: Error, Equatable {}
+
+  struct Sheet {
+    struct State {
+      var count = 0
+    }
+  }
+  struct Destination {
+    enum State {
+      case alert
+      case sheet(Sheet.State)
+    }
+  }
 #endif


### PR DESCRIPTION
We can take a utility function from [Custom
Dump](https://github.com/pointfreeco/swift-custom-dump) to improve the output of failure messages.