### PR TITLE
Breaking change to CasePath.modify

### DIFF
--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -1178,9 +1178,22 @@ final class CasePathsTests: XCTestCase {
   func testModify() throws {
     enum Foo: Equatable { case bar(Int) }
     var foo = Foo.bar(42)
-    try (/Foo.bar).modify(&foo) { $0 *= 2 }
+    (/Foo.bar).modify(&foo) { $0 *= 2 }
     XCTAssertEqual(foo, .bar(84))
   }
+
+  #if DEBUG && (os(iOS) || os(macOS) || os(tvOS) || os(watchOS))
+    func testModify_Failure() throws {
+      enum Foo: Equatable { case bar(Int), baz(Int) }
+      var foo = Foo.bar(42)
+      XCTExpectFailure {
+        $0.compactDescription == """
+          Can't modify unrelated case "bar"
+          """
+      }
+      (/Foo.baz).modify(&foo) { $0 *= 2 }
+    }
+  #endif
 
   func testRegression_gh72() throws {
     enum E1 {


### PR DESCRIPTION
We'd like to make a breaking change to `CasePath.modify`:

```diff
-func modify<R>(inout Enum, (inout Case) throws -> R) throws -> R
+func modify(inout Enum, (inout Case) throws -> Void) rethrows
```

1. It no longer throws (unless the transform closure throws)
2. It no longer returns a result through the continuation.

For 1., we're not sure error handling in the signature makes sense. Modifying the wrong case seems more like a programmer error than anything else. So instead, we'll runtime warn.

For 2., losing `throws` means the result would need to be optionalized. While this is possible, we also don't think values are typically assigned through the result of this closure, so let's remove support for this completely.

For most folks we believe this change will only introduce a build warning:

> **Warning**: No calls to throwing functions occur within 'try' expression

So hopefully not too disruptive!