### PR TITLE
Adding Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,5 @@ jobs:
           tag: 5.8.1-RELEASE
 
       - uses: actions/checkout@v3
-      - name: Build
-        run: swift build -c ${{ matrix.config }}
-      - name: Test
-        run: swift test --skip-build
+      - name: Build & Test
+        run: swift test -c ${{ matrix.config }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,5 +51,7 @@ jobs:
           tag: 5.8.1-RELEASE
 
       - uses: actions/checkout@v3
+      - name: Build All Configurations
+        run: swift build -c ${{ matrix.config }}
       - name: Run tests
-        run: swift test -c ${{ matrix.config }}
+        run: swift test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           tag: 5.8.1-RELEASE
 
       - uses: actions/checkout@v3
-      - name: Build All Configurations
+      - name: Build
         run: swift build -c ${{ matrix.config }}
-      - name: Run tests
-        run: swift test
+      - name: Test
+        run: swift test --skip-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,8 @@ jobs:
     steps:
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-5.8-release
-          tag: 5.8-RELEASE
+          branch: swift-5.8.1-release
+          tag: 5.8.1-RELEASE
 
       - uses: actions/checkout@v3
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,4 +54,4 @@ jobs:
       - name: Build All Configurations
         run: swift build -c ${{ matrix.config }}
       - name: Run tests
-        run: swift test
+        run: swift test -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
       matrix:
         os: [windows-latest]
         config: ['debug', 'release']
+        fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: compnerd/gha-setup-swift@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,4 +54,4 @@ jobs:
       - name: Build All Configurations
         run: swift build -c ${{ matrix.config }}
       - name: Run tests
-        run: swift test -v
+        run: swift test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         os: [windows-latest]
         config: ['debug', 'release']
-        fail-fast: false
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: compnerd/gha-setup-swift@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,13 @@ jobs:
         with:
           branch: swift-5.8.1-release
           tag: 5.8.1-RELEASE
-
       - uses: actions/checkout@v3
-      - name: Build & Test
-        run: swift test -c ${{ matrix.config }}
+      - name: Build
+        run: swift build -c ${{ matrix.config }}
+      - name: Run tests (debug only)
+        # There is an issue that exists in the 5.8.1 toolchain
+        # which fails on release configuration testing, but
+        # this issue is fixed 5.9 so we can remove the if once
+        # that is generally available.
+        if: ${{ matrix.config == 'debug' }}
+        run: swift test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,20 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run tests
         run: make test-linux
+
+  windows:
+    name: Windows
+    strategy:
+      matrix:
+        os: [windows-latest]
+        config: ['debug', 'release']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: compnerd/gha-setup-swift@main
+        with:
+          branch: swift-5.8-release
+          tag: 5.8-RELEASE
+
+      - uses: actions/checkout@v3
+      - name: Run tests
+        run: swift test -c ${{ matrix.config }}


### PR DESCRIPTION
We want to setup Windows CI for all of the Pointfree repos that are used in TCA to ensure that we have cross platform compatibility going forward (or at least to ensure that nothing breaks).