### PR TITLE
📝 Fix doc note of non-void `/` operators

### DIFF
--- a/Sources/CasePaths/EnumReflection.swift
+++ b/Sources/CasePaths/EnumReflection.swift
@@ -1,8 +1,8 @@
 extension CasePath {
   /// Returns a case path for the given embed function.
   ///
-  /// - Note: This operator is only intended to be used with enum cases that have no associated
-  ///   values. Its behavior is otherwise undefined.
+  /// - Note: This operator is only intended to be used with enum case initializers. Its behavior is
+  ///   otherwise undefined.
   /// - Parameter embed: An embed function.
   /// - Returns: A case path.
   public init(_ embed: @escaping (Value) -> Root) {

--- a/Sources/CasePaths/Operators.swift
+++ b/Sources/CasePaths/Operators.swift
@@ -18,8 +18,8 @@ public func ~= <Root, Value>(pattern: CasePath<Root, Value>, value: Root) -> Boo
 
 /// Returns a case path for the given embed function.
 ///
-/// - Note: This operator is only intended to be used with enum cases that have no associated
-///   values. Its behavior is otherwise undefined.
+/// - Note: This operator is only intended to be used with enum case initializers. Its behavior is
+///   otherwise undefined.
 /// - Parameter embed: An embed function.
 /// - Returns: A case path.
 public prefix func / <Root, Value>(
@@ -30,8 +30,8 @@ public prefix func / <Root, Value>(
 
 /// Returns a case path for the given embed function.
 ///
-/// - Note: This operator is only intended to be used with enum cases that have no associated
-///   values. Its behavior is otherwise undefined.
+/// - Note: This operator is only intended to be used with enum case initializers. Its behavior is
+///   otherwise undefined.
 /// - Parameter embed: An embed function.
 /// - Returns: A case path.
 public prefix func / <Root, Value>(


### PR DESCRIPTION
Pretty sure these doc notes were just accidentally copy-pasted from the void variant of the operator, because these two deal with actual values. I replaced it with a note from elsewhere documenting that these should be used indeed only with case initializers.