### PR TITLE
Add `@CasePathable` to any nested enums of a `@CasePathable` enum.

### DIFF
--- a/Sources/CasePathsMacros/CasePathableMacro.swift
+++ b/Sources/CasePathsMacros/CasePathableMacro.swift
@@ -44,6 +44,22 @@ extension CasePathableMacro: ExtensionMacro {
   }
 }
 
+extension CasePathableMacro: MemberAttributeMacro {
+	public static func expansion(
+		of node: SwiftSyntax.AttributeSyntax,
+		attachedTo declaration: some SwiftSyntax.DeclGroupSyntax,
+		providingAttributesFor member: some SwiftSyntax.DeclSyntaxProtocol,
+		in context: some SwiftSyntaxMacros.MacroExpansionContext
+	) throws -> [SwiftSyntax.AttributeSyntax] {
+		if let enumDecl = member.as(EnumDeclSyntax.self) {
+			return [
+				AttributeSyntax(attributeName: IdentifierTypeSyntax(name: .identifier("CasePathable")))
+			]
+		}
+		return []
+	}
+}
+
 extension CasePathableMacro: MemberMacro {
   public static func expansion<
     Declaration: DeclGroupSyntax, Context: MacroExpansionContext

--- a/Sources/CasePathsMacros/CasePathableMacro.swift
+++ b/Sources/CasePathsMacros/CasePathableMacro.swift
@@ -45,19 +45,28 @@ extension CasePathableMacro: ExtensionMacro {
 }
 
 extension CasePathableMacro: MemberAttributeMacro {
-	public static func expansion(
-		of node: SwiftSyntax.AttributeSyntax,
-		attachedTo declaration: some SwiftSyntax.DeclGroupSyntax,
-		providingAttributesFor member: some SwiftSyntax.DeclSyntaxProtocol,
-		in context: some SwiftSyntaxMacros.MacroExpansionContext
-	) throws -> [SwiftSyntax.AttributeSyntax] {
-		if let enumDecl = member.as(EnumDeclSyntax.self) {
-			return [
-				AttributeSyntax(attributeName: IdentifierTypeSyntax(name: .identifier("CasePathable")))
-			]
-		}
-		return []
-	}
+  public static func expansion(
+    of node: SwiftSyntax.AttributeSyntax,
+    attachedTo declaration: some SwiftSyntax.DeclGroupSyntax,
+    providingAttributesFor member: some SwiftSyntax.DeclSyntaxProtocol,
+    in context: some SwiftSyntaxMacros.MacroExpansionContext
+  ) throws -> [SwiftSyntax.AttributeSyntax] {
+    if let enumDecl = member.as(EnumDeclSyntax.self) {
+      var attributes: [String] = ["CasePathable"]
+      for attribute in enumDecl.attributes {
+        guard
+          case let .attribute(attribute) = attribute,
+          let attributeName = attribute.attributeName.as(IdentifierTypeSyntax.self)?.name.text
+        else { continue }
+        attributes.removeAll(where: { $0 == attributeName })
+      }
+      return attributes.map {
+        AttributeSyntax(attributeName: IdentifierTypeSyntax(name: .identifier($0)))
+      }
+    } else {
+      return []
+    }
+  }
 }
 
 extension CasePathableMacro: MemberMacro {

--- a/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
+++ b/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
@@ -302,4 +302,68 @@ final class CasePathableMacroTests: XCTestCase {
       """
     }
   }
+
+  func testNestedCasePathable() {
+    assertMacro {
+      """
+      @CasePathable enum Foo {
+        case bar
+
+        enum FooBar {
+          case baz
+        }
+      }
+      """
+    } expansion: {
+      """
+      enum Foo {
+        case bar
+
+        enum FooBar {
+          case baz
+
+          struct AllCasePaths {
+            var baz: CasePaths.AnyCasePath<FooBar, Void> {
+              CasePaths.AnyCasePath<FooBar, Void>(
+                embed: {
+                  FooBar.baz
+                },
+                extract: {
+                  guard case .baz = $0 else {
+                    return nil
+                  }
+                  return ()
+                }
+              )
+            }
+          }
+          static var allCasePaths: AllCasePaths { AllCasePaths() }
+        }
+
+        struct AllCasePaths {
+          var bar: CasePaths.AnyCasePath<Foo, Void> {
+            CasePaths.AnyCasePath<Foo, Void>(
+              embed: {
+                Foo.bar
+              },
+              extract: {
+                guard case .bar = $0 else {
+                  return nil
+                }
+                return ()
+              }
+            )
+          }
+        }
+        static var allCasePaths: AllCasePaths { AllCasePaths() }
+      }
+
+      extension FooBar: CasePaths.CasePathable {
+      }
+
+      extension Foo: CasePaths.CasePathable {
+      }
+      """
+    }
+  }
 }


### PR DESCRIPTION
This PR adds the `@CasePathable` attribute to any nested enums within an enum.

This is important for TCA as many people use "Domain" actions like...

```
enum Action {
  case view(ViewAction)
  case delegate(DelegateAction)

  enum ViewAction {
    case buttonTapped
  }

  enum DelegateAction {
    case doSomething
  }
}
```

Without this, the `\.view` and `\.delegate` are case pathable but then the only option after that is `.never`.

Adding this will allow for `\.view.buttonTapped` and `\.delegate.doSomething`.