### PR TITLE
Disable windows CI for release.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - case-key-paths
   pull_request:
     branches:
       - '*'
@@ -52,7 +51,9 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        config: ['debug', 'release']
+        config: 
+          - debug
+          #- release
         swift: ['5.9.1']
       fail-fast: false
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
We have started getting strange failures in Windows CI, but only when running in release mode, not debug. So, let's disable for now.