### PR TITLE
Modify isNeededAccessLevelModifier result conditions

### DIFF
--- a/Sources/CasePathsMacros/CasePathableMacro.swift
+++ b/Sources/CasePathsMacros/CasePathableMacro.swift
@@ -238,6 +238,7 @@ extension DeclModifierSyntax {
   var isNeededAccessLevelModifier: Bool {
     switch self.name.tokenKind {
     case .keyword(.public): return true
+    case .keyword(.package): return true
     default: return false
     }
   }

--- a/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
+++ b/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
@@ -167,6 +167,37 @@ final class CasePathableMacroTests: XCTestCase {
     }
     assertMacro {
       """
+      @CasePathable package enum Foo {
+        case bar(Int)
+      }
+      """
+    } expansion: {
+      """
+      package enum Foo {
+        case bar(Int)
+
+        package struct AllCasePaths {
+          package var bar: CasePaths.AnyCasePath<Foo, Int> {
+            CasePaths.AnyCasePath<Foo, Int>(
+              embed: Foo.bar,
+              extract: {
+                guard case let .bar(v0) = $0 else {
+                  return nil
+                }
+                return v0
+              }
+            )
+          }
+        }
+        package static var allCasePaths: AllCasePaths { AllCasePaths() }
+      }
+
+      extension Foo: CasePaths.CasePathable {
+      }
+      """
+    }
+    assertMacro {
+      """
       @CasePathable private enum Foo {
         case bar(Int)
       }


### PR DESCRIPTION
When using the [`package`](https://github.com/apple/swift-evolution/blob/main/proposals/0386-package-access-modifier.md) access modifier, a compile error occurred due to differences in property access levels.

<img width="100%" alt="Before" src="https://github.com/pointfreeco/swift-case-paths/assets/9856514/bdb2d694-ce1d-4fb1-b71d-a669c76a681d">

`package` access modifier is now given a modifier as well as public access modifier.

<img width="400" alt="After" src="https://github.com/pointfreeco/swift-case-paths/assets/9856514/8fc93228-4a38-42ab-a943-2a338c610658">