### PR TITLE
Fix compile error caused by wildcard argument usage

### DIFF
--- a/Sources/CasePathsMacros/CasePathableMacro.swift
+++ b/Sources/CasePathsMacros/CasePathableMacro.swift
@@ -257,6 +257,9 @@ extension EnumCaseElementListSyntax.Element {
         for index in associatedValue.parameters.indices {
           associatedValue.parameters[index].type.trailingTrivia = ""
           associatedValue.parameters[index].defaultValue = nil
+          if associatedValue.parameters[index].firstName?.tokenKind == .wildcard {
+            associatedValue.parameters[index].firstName = nil
+          }
         }
         return "(\(associatedValue.parameters.trimmed))"
       }

--- a/Sources/CasePathsMacros/CasePathableMacro.swift
+++ b/Sources/CasePathsMacros/CasePathableMacro.swift
@@ -258,7 +258,9 @@ extension EnumCaseElementListSyntax.Element {
           associatedValue.parameters[index].type.trailingTrivia = ""
           associatedValue.parameters[index].defaultValue = nil
           if associatedValue.parameters[index].firstName?.tokenKind == .wildcard {
+            associatedValue.parameters[index].colon = nil
             associatedValue.parameters[index].firstName = nil
+            associatedValue.parameters[index].secondName = nil
           }
         }
         return "(\(associatedValue.parameters.trimmed))"

--- a/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
+++ b/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
@@ -313,8 +313,8 @@ final class CasePathableMacroTests: XCTestCase {
         case bar(_ int: Int, _ bool: Bool)
 
         struct AllCasePaths {
-          var bar: CasePaths.AnyCasePath<Foo, (int: Int, bool: Bool)> {
-            CasePaths.AnyCasePath<Foo, (int: Int, bool: Bool)>(
+          var bar: CasePaths.AnyCasePath<Foo, (Int, Bool)> {
+            CasePaths.AnyCasePath<Foo, (Int, Bool)>(
               embed: Foo.bar,
               extract: {
                 guard case let .bar(v0, v1) = $0 else {

--- a/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
+++ b/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
@@ -299,6 +299,40 @@ final class CasePathableMacroTests: XCTestCase {
       """
     }
   }
+  
+  func testWildcard() {
+    assertMacro {
+      """
+      @CasePathable enum Foo {
+        case bar(_ int: Int, _ bool: Bool)
+      }
+      """
+    } expansion: {
+      """
+      enum Foo {
+        case bar(_ int: Int, _ bool: Bool)
+
+        struct AllCasePaths {
+          var bar: CasePaths.AnyCasePath<Foo, (int: Int, bool: Bool)> {
+            CasePaths.AnyCasePath<Foo, (int: Int, bool: Bool)>(
+              embed: Foo.bar,
+              extract: {
+                guard case let .bar(v0, v1) = $0 else {
+                  return nil
+                }
+                return (v0, v1)
+              }
+            )
+          }
+        }
+        static var allCasePaths: AllCasePaths { AllCasePaths() }
+      }
+
+      extension Foo: CasePaths.CasePathable {
+      }
+      """
+    }
+  }
 
   func testSelf() {
     assertMacro {


### PR DESCRIPTION
I ran into a compile error `"Tuple element cannot have two labels"` with some wildcard arguments in enum cases during our TCA 1.4.0 migration. 
I've sorted it out by setting firstName to nil in associatedValue.parameter for those wildcards.
If you've got a neater way to handle this, I'm all ears for suggestions!