### PR TITLE
Support matching on partial key paths using `is`

### DIFF
--- a/Sources/CasePaths/CasePathable.swift
+++ b/Sources/CasePaths/CasePathable.swift
@@ -408,7 +408,7 @@ extension CasePathable {
   /// userActions.filter { $0.is(\.home) }      // [UserAction.home(.onAppear)]
   /// userActions.filter { $0.is(\.settings) }  // [UserAction.settings(.subscribeButtonTapped)]
   /// ```
-  public func `is`<Value>(_ keyPath: PartialCaseKeyPath<Self>) -> Bool {
+  public func `is`(_ keyPath: PartialCaseKeyPath<Self>) -> Bool {
     self[case: keyPath] != nil
   }
 

--- a/Sources/CasePaths/CasePathable.swift
+++ b/Sources/CasePaths/CasePathable.swift
@@ -408,7 +408,7 @@ extension CasePathable {
   /// userActions.filter { $0.is(\.home) }      // [UserAction.home(.onAppear)]
   /// userActions.filter { $0.is(\.settings) }  // [UserAction.settings(.subscribeButtonTapped)]
   /// ```
-  public func `is`<Value>(_ keyPath: CaseKeyPath<Self, Value>) -> Bool {
+  public func `is`<Value>(_ keyPath: PartialCaseKeyPath<Self>) -> Bool {
     self[case: keyPath] != nil
   }
 


### PR DESCRIPTION
Updated the signature to be a `PartialCaseKeyPath` which is all that is required for this function to work.

Makes it possible to write algorithms that operate on a collection of case key paths for a given type, for example:

```swift
extension CasePathable {
  func isOneOf<CaseKeyPaths: Sequence>(_ keyPaths: CaseKeyPaths) -> Bool where CaseKeyPaths.Element == PartialCaseKeyPath<Self> {
    keyPaths.contains(where: { self.is($0) })
  }
}
```