### PR TITLE
Performance: Access case path directly in dynamic member lookup

### DIFF
--- a/Sources/CasePaths/CasePathable.swift
+++ b/Sources/CasePaths/CasePathable.swift
@@ -387,8 +387,10 @@ extension CasePathable {
   /// userActions.compactMap(\.home)      // [HomeAction.onAppear]
   /// userActions.compactMap(\.settings)  // [SettingsAction.subscribeButtonTapped]
   /// ```
-  public subscript<Value>(dynamicMember keyPath: CaseKeyPath<Self, Value>) -> Value? {
-    self[case: keyPath]
+  public subscript<Value>(
+    dynamicMember keyPath: KeyPath<Self.AllCasePaths, AnyCasePath<Self, Value>>
+  ) -> Value? {
+    Self.allCasePaths[keyPath: keyPath].extract(from: self)
   }
 
   /// Tests the associated value of a case.

--- a/Sources/swift-case-paths-benchmark/main.swift
+++ b/Sources/swift-case-paths-benchmark/main.swift
@@ -24,7 +24,7 @@ import CasePaths
  Case Key Path (Appended: 10, Cached): Extract              9333.000 ns ±   5.80 %     150034
  Case Key Path (Appended: 10, Cached + Converted): Embed    3625.000 ns ±   5.56 %     381696
  Case Key Path (Appended: 10, Cached + Converted): Extract  4875.000 ns ±   8.08 %     285089
- Case Pathable (Dynamic Member Lookup: 10)                 19458.000 ns ±   4.13 %      72318
+ Case Pathable (Dynamic Member Lookup: 10)                     0.000 ns ±    inf %     1000000
  */
 
 benchmark("Case Path Reflection (Appended: 2): Embed") {


### PR DESCRIPTION
Case key paths are slightly expensive to resolve since they need to create a `Case` value under the hood, and apply a dynamic key path to it to build up something composed. Because dynamic member lookup only ever cares about one component at a time, we can bypass this extra work and access the case path directly.