### PR TITLE
Add Optional case path for chaining into `some` case

### DIFF
--- a/Sources/CasePaths/Optional+CasePathable.swift
+++ b/Sources/CasePaths/Optional+CasePathable.swift
@@ -1,4 +1,5 @@
 extension Optional: CasePathable {
+  @dynamicMemberLookup
   public struct AllCasePaths {
     public var none: AnyCasePath<Optional, Void> {
       AnyCasePath(
@@ -16,6 +17,20 @@ extension Optional: CasePathable {
         extract: {
           guard case let .some(value) = $0 else { return nil }
           return value
+        }
+      )
+    }
+
+    public subscript<Member>(
+      dynamicMember keyPath: KeyPath<Wrapped.AllCasePaths, AnyCasePath<Wrapped, Member>>
+    ) -> AnyCasePath<Optional, Member>
+    where Wrapped: CasePathable {
+      let casePath = Wrapped.allCasePaths[keyPath: keyPath]
+      return AnyCasePath(
+        embed: { .some(casePath.embed($0)) },
+        extract: {
+          guard let wrapped = $0 else { return nil }
+          return casePath.extract(from: wrapped)
         }
       )
     }

--- a/Sources/CasePaths/Optional+CasePathable.swift
+++ b/Sources/CasePaths/Optional+CasePathable.swift
@@ -40,3 +40,12 @@ extension Optional: CasePathable {
     AllCasePaths()
   }
 }
+
+extension Case {
+  public subscript<Member>(
+    dynamicMember keyPath: KeyPath<Value.AllCasePaths, AnyCasePath<Value, Member?>>
+  ) -> Case<Member>
+  where Value: CasePathable {
+    self[dynamicMember: keyPath].some
+  }
+}

--- a/Sources/CasePaths/Optional+CasePathable.swift
+++ b/Sources/CasePaths/Optional+CasePathable.swift
@@ -29,8 +29,8 @@ extension Optional: CasePathable {
       return AnyCasePath(
         embed: { .some(casePath.embed($0)) },
         extract: {
-          guard let wrapped = $0 else { return nil }
-          return casePath.extract(from: wrapped)
+          guard case let .some(value) = $0 else { return nil }
+          return casePath.extract(from: value)
         }
       )
     }

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -16,6 +16,7 @@ final class CasePathsTests: XCTestCase {
       XCTAssertEqual(somePath(42), 42)
       XCTAssertEqual(nonePath(), nil)
     #endif
+    XCTAssertEqual(Fizz.buzz(.fizzBuzz(.int(42)))[case: \.buzz.fizzBuzz.int], 42)
   }
 
   func testResult() {
@@ -160,5 +161,14 @@ final class CasePathsTests: XCTestCase {
     case string(String)
   }
   @CasePathable enum Blob: Equatable {
+  }
+  @CasePathable @dynamicMemberLookup enum Fizz: Equatable {
+    case buzz(Buzz?)
+  }
+  @CasePathable @dynamicMemberLookup enum Buzz: Equatable {
+    case fizzBuzz(FizzBuzz?)
+  }
+  @CasePathable @dynamicMemberLookup enum FizzBuzz: Equatable {
+    case int(Int)
   }
 #endif

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -18,6 +18,13 @@ final class CasePathsTests: XCTestCase {
     #endif
     #if swift(>=5.9)
       XCTAssertEqual(Fizz.buzz(.fizzBuzz(.int(42)))[case: \.buzz.fizzBuzz.int], 42)
+      let buzzPath1: CaseKeyPath<Fizz, Buzz?> = \Fizz.Cases.buzz
+      let buzzPath2: CaseKeyPath<Fizz, Buzz> = \Fizz.Cases.buzz
+      XCTAssertEqual(buzzPath1, \.buzz)
+      XCTAssertEqual(buzzPath2, \.buzz)
+      let buzzPath3 = \Fizz.Cases.buzz
+      XCTAssertNotEqual(buzzPath1, buzzPath3)
+      XCTAssertEqual(buzzPath2, buzzPath3)
     #endif
   }
 

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -16,7 +16,9 @@ final class CasePathsTests: XCTestCase {
       XCTAssertEqual(somePath(42), 42)
       XCTAssertEqual(nonePath(), nil)
     #endif
-    XCTAssertEqual(Fizz.buzz(.fizzBuzz(.int(42)))[case: \.buzz.fizzBuzz.int], 42)
+    #if swift(>=5.9)
+      XCTAssertEqual(Fizz.buzz(.fizzBuzz(.int(42)))[case: \.buzz.fizzBuzz.int], 42)
+    #endif
   }
 
   func testResult() {


### PR DESCRIPTION
Swift allows us to omit `.some` and does the work to implicitly wrap optionals for us:

```swift
let _: Int? = 42

// Equivalent to:
let _: Int? = .some(42)
```

So why not do the same in case paths? Instead of forcing `.some` when going through an optional, we can go directly:

```swift
enum Foo { case bar(Bar?) }
enum Bar { case baz(Int) }

// Before:
\Foo.Cases.bar.some.baz

// After:
\Foo.Cases.bar.baz
```