### PR TITLE
Simplify optional flattening

### DIFF
--- a/Sources/CasePaths/Never+CasePathable.swift
+++ b/Sources/CasePaths/Never+CasePathable.swift
@@ -6,6 +6,10 @@ extension Never: CasePathable {
 }
 
 extension Case {
+  /// A case path that can never embed or extract a value.
+  ///
+  /// This property can chain any case path into a `Never` value, which, as an uninhabited type,
+  /// cannot be embedded nor extracted from an enum.
   public var never: Case<Never> {
     func absurd<T>(_: Never) -> T {}
     return Case<Never>(embed: absurd, extract: { (_: Value) in nil })

--- a/Sources/CasePaths/Optional+CasePathable.swift
+++ b/Sources/CasePaths/Optional+CasePathable.swift
@@ -1,6 +1,6 @@
 extension Optional: CasePathable {
-  @dynamicMemberLookup
   public struct AllCasePaths {
+    /// A case path to the absence of a value.
     public var none: AnyCasePath<Optional, Void> {
       AnyCasePath(
         embed: { .none },
@@ -11,26 +11,13 @@ extension Optional: CasePathable {
       )
     }
 
+    /// A case path to the presence of a value.
     public var some: AnyCasePath<Optional, Wrapped> {
       AnyCasePath(
         embed: { .some($0) },
         extract: {
           guard case let .some(value) = $0 else { return nil }
           return value
-        }
-      )
-    }
-
-    public subscript<Member>(
-      dynamicMember keyPath: KeyPath<Wrapped.AllCasePaths, AnyCasePath<Wrapped, Member>>
-    ) -> AnyCasePath<Optional, Member>
-    where Wrapped: CasePathable {
-      let casePath = Wrapped.allCasePaths[keyPath: keyPath]
-      return AnyCasePath(
-        embed: { .some(casePath.embed($0)) },
-        extract: {
-          guard case let .some(value) = $0 else { return nil }
-          return casePath.extract(from: value)
         }
       )
     }
@@ -42,6 +29,10 @@ extension Optional: CasePathable {
 }
 
 extension Case {
+  /// A case path to the presence of a nested value.
+  ///
+  /// This subscript can chain into an optional's wrapped value without explicitly specifying each
+  /// `none` component.
   public subscript<Member>(
     dynamicMember keyPath: KeyPath<Value.AllCasePaths, AnyCasePath<Value, Member?>>
   ) -> Case<Member>

--- a/Sources/CasePaths/Optional+CasePathable.swift
+++ b/Sources/CasePaths/Optional+CasePathable.swift
@@ -32,7 +32,7 @@ extension Case {
   /// A case path to the presence of a nested value.
   ///
   /// This subscript can chain into an optional's wrapped value without explicitly specifying each
-  /// `none` component.
+  /// `some` component.
   public subscript<Member>(
     dynamicMember keyPath: KeyPath<Value.AllCasePaths, AnyCasePath<Value, Member?>>
   ) -> Case<Member>

--- a/Sources/CasePaths/Result+CasePathable.swift
+++ b/Sources/CasePaths/Result+CasePathable.swift
@@ -1,5 +1,6 @@
 extension Result: CasePathable {
   public struct AllCasePaths {
+    /// A success case path, for embedding or extracting a `Success` value.
     public var success: AnyCasePath<Result, Success> {
       AnyCasePath(
         embed: { .success($0) },
@@ -10,6 +11,7 @@ extension Result: CasePathable {
       )
     }
 
+    /// A failure case path, for embedding or extracting a `Failure` value.
     public var failure: AnyCasePath<Result, Failure> {
       AnyCasePath(
         embed: { .failure($0) },


### PR DESCRIPTION
Turns out we only need the `Case` overload.

Also documenting a few paths while I go.