### PR TITLE
Add case path for optional chaining

### DIFF
--- a/Sources/CasePaths/Optional+CasePathable.swift
+++ b/Sources/CasePaths/Optional+CasePathable.swift
@@ -1,4 +1,5 @@
 extension Optional: CasePathable {
+  @dynamicMemberLookup
   public struct AllCasePaths {
     /// A case path to the absence of a value.
     public var none: AnyCasePath<Optional, Void> {
@@ -18,6 +19,21 @@ extension Optional: CasePathable {
         extract: {
           guard case let .some(value) = $0 else { return nil }
           return value
+        }
+      )
+    }
+
+    /// A case path to an optional-chained value.
+    public subscript<Member>(
+      dynamicMember keyPath: KeyPath<Wrapped.AllCasePaths, AnyCasePath<Wrapped, Member>>
+    ) -> AnyCasePath<Optional, Member?>
+    where Wrapped: CasePathable {
+      let casePath = Wrapped.allCasePaths[keyPath: keyPath]
+      return AnyCasePath(
+        embed: { $0.map(casePath.embed) },
+        extract: {
+          guard case let .some(value) = $0 else { return nil }
+          return casePath.extract(from: value)
         }
       )
     }

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -25,6 +25,8 @@ final class CasePathsTests: XCTestCase {
       let buzzPath3 = \Fizz.Cases.buzz
       XCTAssertNotEqual(buzzPath1, buzzPath3)
       XCTAssertEqual(buzzPath2, buzzPath3)
+      XCTAssertEqual(ifLet(state: \Fizz.buzz, action: \Fizz.Cases.buzz), 42)
+      XCTAssertEqual(ifLet(state: \Fizz.buzz, action: \Foo.Cases.bar), nil)
     #endif
   }
 
@@ -180,4 +182,8 @@ final class CasePathsTests: XCTestCase {
   @CasePathable @dynamicMemberLookup enum FizzBuzz: Equatable {
     case int(Int)
   }
+
+  func ifLet<A, B, C, D>(state: KeyPath<A, B?>, action: CaseKeyPath<C, D?>) -> Int? { 42 }
+  @_disfavoredOverload
+  func ifLet<A, B, C, D>(state: KeyPath<A, B?>, action: CaseKeyPath<C, D>) -> Int? { nil }
 #endif

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -27,6 +27,11 @@ final class CasePathsTests: XCTestCase {
       XCTAssertEqual(buzzPath2, buzzPath3)
       XCTAssertEqual(ifLet(state: \Fizz.buzz, action: \Fizz.Cases.buzz), 42)
       XCTAssertEqual(ifLet(state: \Fizz.buzz, action: \Foo.Cases.bar), nil)
+      let fizzBuzzPath1: CaseKeyPath<Fizz, Int?> = \Fizz.Cases.buzz.fizzBuzz.int
+      let fizzBuzzPath2: CaseKeyPath<Fizz, Int> = \Fizz.Cases.buzz.fizzBuzz.int
+      let fizzBuzzPath3 = \Fizz.Cases.buzz.fizzBuzz.int
+      XCTAssertNotEqual(fizzBuzzPath1, fizzBuzzPath3)
+      XCTAssertEqual(fizzBuzzPath2, fizzBuzzPath3)
     #endif
   }
 


### PR DESCRIPTION
While #139/#140 added support for flattening optionals, this PR adds support for chaining _into_ optionals. This is useful for when an API takes a case key path to an optional value, but you want to chain into another value and keep things optional.