### PR TITLE
Fix fatal bug in `is(_:)`

### DIFF
--- a/Sources/CasePaths/CasePathable.swift
+++ b/Sources/CasePaths/CasePathable.swift
@@ -410,7 +410,13 @@ extension CasePathable {
   /// userActions.filter { $0.is(\.home) }      // [UserAction.home(.onAppear)]
   /// userActions.filter { $0.is(\.settings) }  // [UserAction.settings(.subscribeButtonTapped)]
   /// ```
+  @_disfavoredOverload
   public func `is`(_ keyPath: PartialCaseKeyPath<Self>) -> Bool {
+    self[case: keyPath] != nil
+  }
+
+  /// Tests the associated value of a case.
+  public func `is`<Value>(_ keyPath: CaseKeyPath<Self, Value>) -> Bool where Value: _OptionalProtocol {
     self[case: keyPath] != nil
   }
 

--- a/Sources/CasePaths/CasePathable.swift
+++ b/Sources/CasePaths/CasePathable.swift
@@ -415,8 +415,7 @@ extension CasePathable {
     self[case: keyPath] != nil
   }
 
-  /// Tests the associated value of a case.
-  public func `is`<Value>(_ keyPath: CaseKeyPath<Self, Value>) -> Bool where Value: _OptionalProtocol {
+  public func `is`<Wrapped>(_ keyPath: CaseKeyPath<Self, Wrapped?>) -> Bool {
     self[case: keyPath] != nil
   }
 

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -132,14 +132,14 @@ final class CasePathsTests: XCTestCase {
     func testMatch() {
       switch Foo.bar(.int(42)) {
       case \.bar.int:
-        return
+        break
       default:
         XCTFail()
       }
 
       switch Foo.bar(.int(42)) {
       case \.bar:
-        return
+        break
       default:
         XCTFail()
       }
@@ -150,6 +150,9 @@ final class CasePathsTests: XCTestCase {
       XCTAssertFalse(Foo.bar(.int(42)).is(\.baz.string))
       XCTAssertFalse(Foo.bar(.int(42)).is(\.blob))
       XCTAssertFalse(Foo.bar(.int(42)).is(\.fizzBuzz))
+      XCTAssertTrue(Foo.foo(nil).is(\.foo))
+      XCTAssertTrue(Foo.foo("").is(\.foo))
+      XCTAssertFalse(Foo.foo(nil).is(\.bar))
     }
 
     func testPartialCaseKeyPath() {
@@ -169,6 +172,7 @@ final class CasePathsTests: XCTestCase {
     case baz(Baz)
     case fizzBuzz
     case blob(Blob)
+    case foo(String?)
   }
   @CasePathable @dynamicMemberLookup enum Bar: Equatable {
     case int(Int)

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -151,6 +151,7 @@ final class CasePathsTests: XCTestCase {
       XCTAssertFalse(Foo.bar(.int(42)).is(\.blob))
       XCTAssertFalse(Foo.bar(.int(42)).is(\.fizzBuzz))
       XCTAssertTrue(Foo.foo(nil).is(\.foo))
+      XCTAssertTrue(Foo.foo(nil).is(\.foo.none))
       XCTAssertTrue(Foo.foo("").is(\.foo))
       XCTAssertFalse(Foo.foo(nil).is(\.bar))
     }


### PR DESCRIPTION
Hi there, I found a bug in `is(_:)`.

In version 1.2.0, the handling of optional associated values has been improved. Specifically, the subscript(case:) now correctly returns a value without unnecessarily wrapping it in an additional Optional layer when the associated value is already an Optional. However, this improvement has introduced a significant bug.

Consider the following enum as an example:
```Swift
enum Foo {
  case c1
  case c2(String?)
}
```
When using the is(_:) method with c2's associated value set to nil, like so:
```Swift
Foo.c2(nil).is(\.c2) // false
```
The expected result would be true, but it incorrectly returns false. This is a direct consequence of the changes in version 1.2.0. Prior to this change, the value of `self[case: keyPath]`  used in the implementation of `is(_:)` would be Optional(nil), bug which is not nil, thus functioning correctly. However, post-change, the value of `self[case: keyPath]` becomes nil, leading to incorrect behavior even when the case matches.

On the other hand, with a non-nil associated value such as:
```Swift
Foo.c2("foo").is(\.c2) // true
```
The method works correctly because self[case: keyPath] returns "foo".

This pull request introduces a code change to prevent the execution of the line at 52 in Optional+CasePathable that was added in 1.2.0:
```Swift
public subscript<Member>(
  dynamicMember keyPath: KeyPath<Value.AllCasePaths, AnyCasePath<Value, Member?>>
) -> Case<Member>
where Value: CasePathable {
  self[dynamicMember: keyPath].some
}
```