### PR TITLE
Open existentials sent to `PartialCaseKeyPath.callAsFunction`

### DIFF
--- a/Sources/CasePaths/CasePathable.swift
+++ b/Sources/CasePaths/CasePathable.swift
@@ -279,11 +279,14 @@ extension PartialCaseKeyPath {
   ///   type, the operation will fail.
   /// - Returns: An enum for the case of this key path that holds the given value, or `nil`.
   @_disfavoredOverload
-  public func callAsFunction<Enum: CasePathable, AnyAssociatedValue>(
-    _ value: AnyAssociatedValue
+  public func callAsFunction<Enum: CasePathable>(
+    _ value: Any
   ) -> Enum?
   where Root == Case<Enum> {
-    (Case<Enum>()[keyPath: self] as? Case<AnyAssociatedValue>)?.embed(value) as? Enum
+    func open<AnyAssociatedValue>(_ value: AnyAssociatedValue) -> Enum? {
+      (Case<Enum>()[keyPath: self] as? Case<AnyAssociatedValue>)?.embed(value) as? Enum
+    }
+    return _openExistential(value, do: open)
   }
 }
 

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -164,10 +164,30 @@ final class CasePathsTests: XCTestCase {
       XCTAssertEqual(.int(42), Foo.bar(.int(42))[case: partialPath] as? Bar)
       XCTAssertNil(Foo.baz(.string("Hello"))[case: partialPath])
     }
+
+    func testExistentials() {
+      let caseA: PartialCaseKeyPath<A> = \.a
+      let caseB: PartialCaseKeyPath<B> = \.b
+
+      let a = A.a("Hello")
+      guard let valueA = a[case: caseA] else { return XCTFail() }
+      guard let b = caseB(valueA) else { return XCTFail() }
+      XCTAssertEqual(b, .b("Hello"))
+    }
   #endif
 }
 
 #if swift(>=5.9)
+  @CasePathable
+  enum A: Equatable {
+    case a(String)
+  }
+
+  @CasePathable
+  enum B: Equatable {
+    case b(String)
+  }
+
   @CasePathable @dynamicMemberLookup enum Foo: Equatable {
     case bar(Bar)
     case baz(Baz)


### PR DESCRIPTION
Currently, sending an `Any` value to `PartialCaseKeyPath.callAsFunction` will always fail because the existential isn't opened. This should fix that.