### PR TITLE
Fixes around optionals and partial case key paths

### DIFF
--- a/Sources/CasePaths/CasePathable.swift
+++ b/Sources/CasePaths/CasePathable.swift
@@ -272,7 +272,7 @@ extension CaseKeyPath {
 /// A partially type-erased key path, from a concrete root enum to any resulting value type.
 public typealias PartialCaseKeyPath<Root> = PartialKeyPath<Case<Root>>
 
-extension PartialCaseKeyPath {
+extension _AppendKeyPath {
   /// Attempts to embeds any value in an enum at this case key path's case.
   ///
   /// - Parameter value: A value to embed. If the value type does not match the case path's value
@@ -282,9 +282,10 @@ extension PartialCaseKeyPath {
   public func callAsFunction<Enum: CasePathable>(
     _ value: Any
   ) -> Enum?
-  where Root == Case<Enum> {
+  where Self == PartialCaseKeyPath<Enum> {
     func open<AnyAssociatedValue>(_ value: AnyAssociatedValue) -> Enum? {
       (Case<Enum>()[keyPath: self] as? Case<AnyAssociatedValue>)?.embed(value) as? Enum
+        ?? (Case<Enum>()[keyPath: self] as? Case<AnyAssociatedValue?>)?.embed(value) as? Enum
     }
     return _openExistential(value, do: open)
   }

--- a/Sources/CasePaths/Optional+CasePathable.swift
+++ b/Sources/CasePaths/Optional+CasePathable.swift
@@ -24,6 +24,7 @@ extension Optional: CasePathable {
     }
 
     /// A case path to an optional-chained value.
+    @_disfavoredOverload
     public subscript<Member>(
       dynamicMember keyPath: KeyPath<Wrapped.AllCasePaths, AnyCasePath<Wrapped, Member>>
     ) -> AnyCasePath<Optional, Member?>
@@ -49,6 +50,7 @@ extension Case {
   ///
   /// This subscript can chain into an optional's wrapped value without explicitly specifying each
   /// `some` component.
+  @_disfavoredOverload
   public subscript<Member>(
     dynamicMember keyPath: KeyPath<Value.AllCasePaths, AnyCasePath<Value, Member?>>
   ) -> Case<Member>

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -23,8 +23,8 @@ final class CasePathsTests: XCTestCase {
       XCTAssertEqual(buzzPath1, \.buzz)
       XCTAssertEqual(buzzPath2, \.buzz)
       let buzzPath3 = \Fizz.Cases.buzz
-      XCTAssertNotEqual(buzzPath1, buzzPath3)
-      XCTAssertEqual(buzzPath2, buzzPath3)
+      XCTAssertEqual(buzzPath1, buzzPath3)
+      XCTAssertNotEqual(buzzPath2, buzzPath3)
       XCTAssertEqual(ifLet(state: \Fizz.buzz, action: \Fizz.Cases.buzz), 42)
       XCTAssertEqual(ifLet(state: \Fizz.buzz, action: \Foo.Cases.bar), nil)
       let fizzBuzzPath1: CaseKeyPath<Fizz, Int?> = \Fizz.Cases.buzz.fizzBuzz.int


### PR DESCRIPTION
We recently added code that can flatten optionals in a couple of ways, but because these methods weren't disfavored, they take precedent and can produce case key paths incapable of expressing what you want, like the ability to embed a optional in an case that contains an optional:

```swift
@CasePathable
enum Foo {
  case bar(Int?)
}

let kp = \Foo.Cases.bar  // CaseKeyPath<Foo, Int>, not <Foo, Int?>
kp(nil)  // 'nil' is not compatible with expected argument type 'Int'
```

This PR disfavors these overloads to allow you to flatten optionals contextually, but by default will leave them alone.

It also fixes a bug in `PartialCaseKeyPath.callAsFunction` that would prevent non-optionals from being promoted to optionals in cases that expect them:

```swift
let kp: PartialCaseKeyPath<Foo> = \.bar

// Before:
kp(42)  // nil

// After:
kp(42)  // Foo.bar(.some(42))
```

Finally, this PR fixes a bug in which `PartialCaseKeyPath.callAsFunction` was technically available on `CaseKeyPath`, which meant you could call it with any value:

```swift
let kp = \Foo.Cases.bar

// Before:
kp("Hello")  // nil

// After:
kp("Hello")  // Cannot convert value of type 'String' to expected argument type 'Int?'
```