### PR TITLE
Quality-of-life improvements

### DIFF
--- a/Sources/CasePaths/Never+CasePathable.swift
+++ b/Sources/CasePaths/Never+CasePathable.swift
@@ -5,7 +5,7 @@ extension Never: CasePathable {
   }
 }
 
-extension Case {
+extension Case where Value: CasePathable {
   /// A case path that can never embed or extract a value.
   ///
   /// This property can chain any case path into a `Never` value, which, as an uninhabited type,
@@ -15,3 +15,21 @@ extension Case {
     return Case<Never>(embed: absurd, extract: { (_: Value) in nil })
   }
 }
+
+#if DEBUG, swift(>=5.9)
+  extension Case {
+    /// ⚠️ The current enum is not `@CasePathable` and cannot derive key paths into its cases. Mark
+    /// this enum `@CasePathable`, or extend it with a manual `CasePathable` conformance to enable
+    /// case key path syntax.
+    ///
+    /// A case path that can never embed or extract a value.
+    ///
+    /// This property can chain any case path into a `Never` value, which, as an uninhabited type,
+    /// cannot be embedded nor extracted from an enum.
+    @_documentation(visibility: private)
+    public var never: Case<Never> {
+      func absurd<T>(_: Never) -> T {}
+      return Case<Never>(embed: absurd, extract: { (_: Value) in nil })
+    }
+  }
+#endif

--- a/Sources/CasePaths/Never+CasePathable.swift
+++ b/Sources/CasePaths/Never+CasePathable.swift
@@ -16,20 +16,10 @@ extension Case where Value: CasePathable {
   }
 }
 
-#if DEBUG, swift(>=5.9)
-  extension Case {
-    /// ⚠️ The current enum is not `@CasePathable` and cannot derive key paths into its cases. Mark
-    /// this enum `@CasePathable`, or extend it with a manual `CasePathable` conformance to enable
-    /// case key path syntax.
-    ///
-    /// A case path that can never embed or extract a value.
-    ///
-    /// This property can chain any case path into a `Never` value, which, as an uninhabited type,
-    /// cannot be embedded nor extracted from an enum.
-    @_documentation(visibility: private)
-    public var never: Case<Never> {
-      func absurd<T>(_: Never) -> T {}
-      return Case<Never>(embed: absurd, extract: { (_: Value) in nil })
-    }
+extension Case {
+  @available(*, deprecated, message: "This enum must be '@CasePathable' to enable key path syntax")
+  public var never: Case<Never> {
+    func absurd<T>(_: Never) -> T {}
+    return Case<Never>(embed: absurd, extract: { (_: Value) in nil })
   }
-#endif
+}

--- a/Tests/CasePaths copy.xctestplan
+++ b/Tests/CasePaths copy.xctestplan
@@ -1,0 +1,18 @@
+{
+  "configurations" : [
+    {
+      "id" : "2400C241-35D6-4B6B-B6EA-A4105C2738D6",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+
+  ],
+  "version" : 1
+}

--- a/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
+++ b/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
@@ -607,18 +607,43 @@ final class CasePathableMacroTests: XCTestCase {
   func testDocumentation() {
     assertMacro {
       """
-      @available(iOS, unavailable)
       @CasePathable
       enum Foo {
+
         /// The bar case.
         case bar
+
+        /// The baz case.
+        ///
+        /// A case for baz.
+        case baz
+
+        /**
+         The fizz buzz case.
+
+         A case for fizz and buzz.
+         */
+        case fizz, buzz
       }
       """
     } expansion: {
       """
-      @available(iOS, unavailable)
       enum Foo {
+
+        /// The bar case.
         case bar
+
+        /// The baz case.
+        ///
+        /// A case for baz.
+        case baz
+
+        /**
+         The fizz buzz case.
+
+         A case for fizz and buzz.
+         */
+        case fizz, buzz
 
         public struct AllCasePaths {
           /// The bar case.
@@ -635,11 +660,63 @@ final class CasePathableMacroTests: XCTestCase {
               }
             )
           }
+          /// The baz case.
+          ///
+          /// A case for baz.
+          public var baz: CasePaths.AnyCasePath<Foo, Void> {
+            CasePaths.AnyCasePath<Foo, Void>(
+              embed: {
+                Foo.baz
+              },
+              extract: {
+                guard case .baz = $0 else {
+                  return nil
+                }
+                return ()
+              }
+            )
+          }
+          /**
+         The fizz buzz case.
+
+         A case for fizz and buzz.
+         */
+          public var fizz: CasePaths.AnyCasePath<Foo, Void> {
+            CasePaths.AnyCasePath<Foo, Void>(
+              embed: {
+                Foo.fizz
+              },
+              extract: {
+                guard case .fizz = $0 else {
+                  return nil
+                }
+                return ()
+              }
+            )
+          }
+          /**
+         The fizz buzz case.
+
+         A case for fizz and buzz.
+         */
+          public var buzz: CasePaths.AnyCasePath<Foo, Void> {
+            CasePaths.AnyCasePath<Foo, Void>(
+              embed: {
+                Foo.buzz
+              },
+              extract: {
+                guard case .buzz = $0 else {
+                  return nil
+                }
+                return ()
+              }
+            )
+          }
         }
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      @available(iOS, unavailable) extension Foo: CasePaths.CasePathable {
+      extension Foo: CasePaths.CasePathable {
       }
       """
     }

--- a/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
+++ b/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
@@ -603,4 +603,45 @@ final class CasePathableMacroTests: XCTestCase {
       """
     }
   }
+
+  func testDocumentation() {
+    assertMacro {
+      """
+      @available(iOS, unavailable)
+      @CasePathable
+      enum Foo {
+        /// The bar case.
+        case bar
+      }
+      """
+    } expansion: {
+      """
+      @available(iOS, unavailable)
+      enum Foo {
+        case bar
+
+        public struct AllCasePaths {
+          /// The bar case.
+          public var bar: CasePaths.AnyCasePath<Foo, Void> {
+            CasePaths.AnyCasePath<Foo, Void>(
+              embed: {
+                Foo.bar
+              },
+              extract: {
+                guard case .bar = $0 else {
+                  return nil
+                }
+                return ()
+              }
+            )
+          }
+        }
+        public static var allCasePaths: AllCasePaths { AllCasePaths() }
+      }
+
+      @available(iOS, unavailable) extension Foo: CasePaths.CasePathable {
+      }
+      """
+    }
+  }
 }


### PR DESCRIPTION
- Adds a deprecated overload of `.never` that calls out when an enum is not case-pathable and thus does not have any of its cases available via key path syntax.
- Propagates case documentation to the generated case path. This makes autocomplete, etc., a bit nicer, as it explains to the user which case you are completing to when it is documented.