### PR TITLE
leadingTrivia indentation trimming calculation should not discard zero values

### DIFF
--- a/Sources/CasePathsMacros/CasePathableMacro.swift
+++ b/Sources/CasePathsMacros/CasePathableMacro.swift
@@ -143,7 +143,7 @@ extension CasePathableMacro: MemberMacro {
       let indent =
         leadingTriviaLines
         .compactMap { $0.isEmpty ? nil : $0.prefix(while: \.isWhitespace).count }
-        .min(by: { (lhs: Int, rhs: Int) -> Bool in lhs == 0 ? lhs > rhs : lhs < rhs })
+        .min(by: { (lhs: Int, rhs: Int) -> Bool in lhs < rhs })
         ?? 0
       let leadingTrivia =
         leadingTriviaLines

--- a/Sources/CasePathsMacros/CasePathableMacro.swift
+++ b/Sources/CasePathsMacros/CasePathableMacro.swift
@@ -149,6 +149,7 @@ extension CasePathableMacro: MemberMacro {
         leadingTriviaLines
         .map { String($0.dropFirst(indent)) }
         .joined(separator: "\n")
+        .trimmingSuffix(while: { $0.isWhitespace && !$0.isNewline })
       return """
         \(raw: leadingTrivia)public var \(caseName): \
         \(raw: qualifiedCasePathTypeName)<\(enumName), \(raw: associatedValueName)> {
@@ -421,4 +422,17 @@ final class SelfRewriter: SyntaxRewriter {
     else { return super.visit(node) }
     return super.visit(node.with(\.name, self.selfEquivalent))
   }
+}
+
+extension StringProtocol {
+    @inline(__always)
+    func trimmingSuffix(while condition: (Element) throws -> Bool) rethrows -> Self.SubSequence {
+        var view = self[...]
+        
+        while let character = view.last, try condition(character) {
+            view = view.dropLast()
+        }
+        
+        return view
+    }
 }

--- a/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
+++ b/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
@@ -721,4 +721,47 @@ final class CasePathableMacroTests: XCTestCase {
       """
     }
   }
+  
+  func testDocumentationIndentationTrimming() {
+      assertMacro {
+      """
+      @CasePathable
+      enum Foo {
+        // baz
+      // case foo
+        case bar
+      }
+      """
+      } expansion: {
+        """
+        enum Foo {
+          // baz
+        // case foo
+          case bar
+
+          public struct AllCasePaths {
+              // baz
+            // case foo
+            public var bar: CasePaths.AnyCasePath<Foo, Void> {
+              CasePaths.AnyCasePath<Foo, Void>(
+                embed: {
+                  Foo.bar
+                },
+                extract: {
+                  guard case .bar = $0 else {
+                    return nil
+                  }
+                  return ()
+                }
+              )
+            }
+          }
+          public static var allCasePaths: AllCasePaths { AllCasePaths() }
+        }
+
+        extension Foo: CasePaths.CasePathable {
+        }
+        """
+      }
+  }
 }


### PR DESCRIPTION
With v1.3.1 documentation is now also included for the generated `AllCasePaths` struct.
In order to achieve this the leadingTrivia for each case is appended to the generated properties. To ensure indentation matches, the code discards leading whitespaces from the trivia.
When determining how many characters to trim, the code loops over each line in the leadingTrivia, discarding empty lines and counting the amount of prefixed whitespaces. The smallest value counted is then taken and used as the amount of whitespace to trim from each line.

There is an issue in this last bit of logic where lines without prefixed whitespaces are always ignored. This will cause these lines to be trimmed erroneously. Take the following example:
```swift
@CasePathable
enum MyEnum {
    // TODO: Implement this case
//    case one
    case two
}
```

Because the line `//    case one` is ignored when calculating the minimum amount of whitespace, it is trimmed in the generated code:

```swift
public struct AllCasePaths {
    // TODO: Implement this case
      case one
    public var two: CasePaths.AnyCasePath<MyEnum, Void> {
        ...
    }

    …
}
```

This obviously causes a build failure.

The change removes the bit of logic where lines with zero whitespacing are ignored when calculating the minimum amount of whitespace. As far as I can tell this doesn’t have a negative impact. Tests still pass including`testDocumentation`.