### PR TITLE
CasePathable.modify: Change XCTFail to runtimeWarn as per documentation

### DIFF
--- a/Sources/CasePaths/CasePathable.swift
+++ b/Sources/CasePaths/CasePathable.swift
@@ -479,13 +479,11 @@ extension CasePathable {
   ) {
     let `case` = Case(keyPath)
     guard var value = `case`.extract(from: self) else {
-      XCTFail(
+      runtimeWarn(
         """
         Can't modify '\(String(describing: self))' via 'CaseKeyPath<\(Self.self), \(Value.self)>' \
         (aka '\(String(reflecting: keyPath))')
-        """,
-        file: file,
-        line: line
+        """
       )
       return
     }

--- a/Sources/CasePaths/Internal/RuntimeWarnings.swift
+++ b/Sources/CasePaths/Internal/RuntimeWarnings.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+extension Notification.Name {
+  #if swift(>=5.8)
+    @_documentation(visibility:private)
+    @available(*, deprecated, renamed: "_runtimeWarning")
+    public static let runtimeWarning = Self("CasePaths.runtimeWarning")
+  #else
+    @available(*, deprecated, renamed: "_runtimeWarning")
+    public static let runtimeWarning = Self("CasePaths.runtimeWarning")
+  #endif
+  /// A notification that is posted when a runtime warning is emitted.
+  public static let _runtimeWarning = Self("CasePaths.runtimeWarning")
+}
+
+@_transparent
+@usableFromInline
+@inline(__always)
+func runtimeWarn(
+  _ message: @autoclosure () -> String,
+  category: String? = "CasePaths"
+) {
+  #if DEBUG
+    let message = message()
+    NotificationCenter.default.post(
+      name: ._runtimeWarning,
+      object: nil,
+      userInfo: ["message": message]
+    )
+    let category = category ?? "Runtime Warning"
+    if _XCTIsTesting {
+      XCTFail(message)
+    } else {
+      #if canImport(os)
+        os_log(
+          .fault,
+          dso: dso,
+          log: OSLog(subsystem: "com.apple.runtime-issues", category: category),
+          "%@",
+          message
+        )
+      #else
+        fputs("\(formatter.string(from: Date())) [\(category)] \(message)\n", stderr)
+      #endif
+    }
+  #endif
+}
+
+#if DEBUG
+  import XCTestDynamicOverlay
+
+  #if canImport(os)
+    import os
+
+    // NB: Xcode runtime warnings offer a much better experience than traditional assertions and
+    //     breakpoints, but Apple provides no means of creating custom runtime warnings ourselves.
+    //     To work around this, we hook into SwiftUI's runtime issue delivery mechanism, instead.
+    //
+    // Feedback filed: https://gist.github.com/stephencelis/a8d06383ed6ccde3e5ef5d1b3ad52bbc
+    @usableFromInline
+    let dso = { () -> UnsafeMutableRawPointer in
+      let count = _dyld_image_count()
+      for i in 0..<count {
+        if let name = _dyld_get_image_name(i) {
+          let swiftString = String(cString: name)
+          if swiftString.hasSuffix("/SwiftUI") {
+            if let header = _dyld_get_image_header(i) {
+              return UnsafeMutableRawPointer(mutating: UnsafeRawPointer(header))
+            }
+          }
+        }
+      }
+      return UnsafeMutableRawPointer(mutating: #dsohandle)
+    }()
+  #else
+    import Foundation
+
+    @usableFromInline
+    let formatter: DateFormatter = {
+      let formatter = DateFormatter()
+      formatter.dateFormat = "yyyy-MM-dd HH:MM:SS.sssZ"
+      return formatter
+    }()
+  #endif
+#endif


### PR DESCRIPTION
As per [the documentation](https://swiftpackageindex.com/pointfreeco/swift-case-paths/main/documentation/casepaths/casepathable/modify(_:yield:file:line:)):
> If the enum’s case does not match the given case key path, the mutation will not be applied, and a runtime warning will be logged.

In reality, calling `modify` with a non-matching case will always call `XCTFail`. This PR adds ComposableArchitecture's `RuntimeWarnings.swift` file and uses `runtimeWarn` instead of `XCTFail`.

Alternatively, we could consider changing the documentation to clarify that the use of a non-matching case causes a runtime crash. I'm open to either solution, but a warning log seems a bit more graceful.