### PR TITLE
Enable strict concurrency.

### DIFF
--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -65,3 +65,15 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
   )
 #endif
+
+for target in package.targets {
+  target.swiftSettings = target.swiftSettings ?? []
+  target.swiftSettings?.append(contentsOf: [
+    .enableExperimentalFeature("StrictConcurrency")
+  ])
+  //  target.swiftSettings?.append(
+  //    .unsafeFlags([
+  //      "-enable-library-evolution",
+  //    ])
+  //  )
+}

--- a/Tests/CasePathsTests/DeprecatedTests.swift
+++ b/Tests/CasePathsTests/DeprecatedTests.swift
@@ -1,7 +1,7 @@
 import CasePaths
 import XCTest
 
-protocol TestProtocol {}
+protocol TestProtocol: Sendable {}
 extension Int: TestProtocol {}
 protocol TestClassProtocol: AnyObject {}
 
@@ -465,7 +465,7 @@ final class DeprecatedTests: XCTestCase {
   }
 
   func testContravariantEmbed() {
-    enum Enum {
+    enum Enum: Sendable {
       // associated value type is TestProtocol existential
       case directExistential(TestProtocol)
 


### PR DESCRIPTION
Not much to do in this library. We do have a bunch of sendable warnings for key paths, but that is a Swift issue that will be fixed in Swift 6.
