### PR TITLE
Fix Optional dynamic member lookup

### DIFF
--- a/Sources/CasePaths/CasePathable.swift
+++ b/Sources/CasePaths/CasePathable.swift
@@ -440,12 +440,7 @@ extension CasePathable {
   /// userActions.filter { $0.is(\.home) }      // [UserAction.home(.onAppear)]
   /// userActions.filter { $0.is(\.settings) }  // [UserAction.settings(.subscribeButtonTapped)]
   /// ```
-  @_disfavoredOverload
   public func `is`(_ keyPath: PartialCaseKeyPath<Self>) -> Bool {
-    self[case: keyPath] != nil
-  }
-
-  public func `is`<Wrapped>(_ keyPath: CaseKeyPath<Self, Wrapped?>) -> Bool {
     self[case: keyPath] != nil
   }
 

--- a/Sources/CasePaths/Documentation.docc/CasePathable.md
+++ b/Sources/CasePaths/Documentation.docc/CasePathable.md
@@ -14,8 +14,7 @@
 
 ### Case properties
 
-- ``is(_:)-26xtm``
-- ``is(_:)-8kyve``
+- ``is(_:)``
 - ``subscript(dynamicMember:)-7ik0u``
 - ``subscript(dynamicMember:)-7sz4x``
 

--- a/Sources/CasePaths/Optional+CasePathable.swift
+++ b/Sources/CasePaths/Optional+CasePathable.swift
@@ -33,8 +33,9 @@ extension Optional: CasePathable {
       return AnyCasePath(
         embed: { $0.map(casePath.embed) },
         extract: {
-          guard case let .some(value) = $0 else { return nil }
-          return casePath.extract(from: value)
+          guard case let .some(value) = $0, let member = casePath.extract(from: value)
+          else { return .none }
+          return member
         }
       )
     }

--- a/Sources/CasePaths/Optional+CasePathable.swift
+++ b/Sources/CasePaths/Optional+CasePathable.swift
@@ -33,7 +33,7 @@ extension Optional: CasePathable {
       return AnyCasePath(
         embed: { $0.map(casePath.embed) },
         extract: {
-          guard case let .some(value) = $0, let member = casePath.extract(from: value)
+          guard case let .some(wrapped) = $0, let member = casePath.extract(from: wrapped)
           else { return .none }
           return member
         }

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -182,6 +182,14 @@ final class CasePathsTests: XCTestCase {
       XCTAssertNotNil(foo(String?.some("Blob") as Any))
       XCTAssertNotNil(foo("Blob"))
     }
+
+    func testIs_Optional() {
+      XCTAssertTrue(Optional(Foo.fizzBuzz).is(\.fizzBuzz))
+      XCTAssertFalse(Optional(Foo.fizzBuzz).is(\.bar))
+      XCTAssertFalse(Optional(Foo.fizzBuzz).is(\.baz))
+      XCTAssertFalse(Optional(Foo.fizzBuzz).is(\.blob))
+      XCTAssertFalse(Optional(Foo.fizzBuzz).is(\.foo))
+    }
   #endif
 }
 


### PR DESCRIPTION
Swift optional promotion is sometimes succeeding to return `.some(.none)` where it should be returning `.none`.