### PR TITLE
Handle comments on cases without associated values

### DIFF
--- a/Sources/CasePathsMacros/CasePathableMacro.swift
+++ b/Sources/CasePathsMacros/CasePathableMacro.swift
@@ -84,7 +84,7 @@ extension CasePathableMacro: MemberMacro {
     let rewriter = SelfRewriter(selfEquivalent: enumName)
     let memberBlock = rewriter.rewrite(enumDecl.memberBlock).cast(MemberBlockSyntax.self)
     let rootSwitchCases = generateCases(from: memberBlock.members, enumName: enumName) {
-      "case .\($0.name): return \\.\(raw: $0.name.text)"
+      "case .\(raw: $0.name.text): return \\.\(raw: $0.name.text)"
     }
     let rootSwitch: DeclSyntax =
       rootSwitchCases.isEmpty
@@ -96,7 +96,7 @@ extension CasePathableMacro: MemberMacro {
       """
     let casePaths = generateDeclSyntax(from: memberBlock.members, enumName: enumName)
     let allCases = generateCases(from: memberBlock.members, enumName: enumName) {
-      "allCasePaths.append(\\.\($0.name))"
+      "allCasePaths.append(\\.\(raw: $0.name.text))"
     }
 
     return [

--- a/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
+++ b/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
@@ -978,6 +978,7 @@ final class CasePathableMacroTests: XCTestCase {
         /*Comment before case*/ case baz(Int)
         case fizz(buzz: String)  // Comment on case
         case fizzier/*Comment in case*/(Int, buzzier: String)
+        case fizziest // Comment without associated value
       }
       """
     } expansion: {
@@ -988,6 +989,7 @@ final class CasePathableMacroTests: XCTestCase {
         /*Comment before case*/ case baz(Int)
         case fizz(buzz: String)  // Comment on case
         case fizzier/*Comment in case*/(Int, buzzier: String)
+        case fizziest // Comment without associated value
 
         public struct AllCasePaths: Sequence {
           public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
@@ -998,8 +1000,10 @@ final class CasePathableMacroTests: XCTestCase {
               return \.baz
             case .fizz:
               return \.fizz
-            case .fizzier/*Comment in case*/:
+            case .fizzier:
               return \.fizzier
+            case .fizziest:
+              return \.fizziest
             }
           }
           // Comment above case
@@ -1049,12 +1053,26 @@ final class CasePathableMacroTests: XCTestCase {
               }
             )
           }
+          public var fizziest: CasePaths.AnyCasePath<Foo, Void> {
+            CasePaths.AnyCasePath<Foo, Void>(
+              embed: {
+                Foo.fizziest
+              },
+              extract: {
+                guard case .fizziest = $0 else {
+                  return nil
+                }
+                return ()
+              }
+            )
+          }
           public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Foo>]> {
             var allCasePaths: [PartialCaseKeyPath<Foo>] = []
             allCasePaths.append(\.bar)
             allCasePaths.append(\.baz)
             allCasePaths.append(\.fizz)
-            allCasePaths.append(\.fizzier/*Comment in case*/)
+            allCasePaths.append(\.fizzier)
+            allCasePaths.append(\.fizziest)
             return allCasePaths.makeIterator()
           }
         }

--- a/Tests/CasePathsTests/MacroTests.swift
+++ b/Tests/CasePathsTests/MacroTests.swift
@@ -8,5 +8,6 @@
     /*Comment before case*/ case baz(Int)
     case fizz(buzz: String)  // Comment on case
     case fizzier /*Comment in case*/(Int, buzzier: String)
+    case fizziest
   }
 #endif


### PR DESCRIPTION
- https://pointfreecommunity.slack.com/archives/C04KQQ7NXHV/p1717736207509849?thread_ts=1717708594.669469&cid=C04KQQ7NXHV
- https://github.com/pointfreeco/swift-case-paths/pull/160/

Fixes compilation error for enum cases without associated values that have trailing comments e.g.:

```swift
// Using swift-case-paths 1.4.1
@CasePathable enum Foo {
  case fizz(buzz: String) // Comment on case ✅
  case fizziest // Comment without associated value ❌ 
}
```

Previously, for trailing comments on enum cases without associated values, the macro was generating invalid syntax in two places:

```swift
// public struct AllCasePaths: Sequence {
case .fizziest // Comment without associated value: return \.fizziest ❌

// public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Foo>]> {
allCasePaths.append(\.fizziest // Comment without associated value) ❌
```

I used the same fix from #160 – adding `.text`. This has the side-effect of removing C-style comments outside the root enum declaration as mentioned in [this comment](https://github.com/pointfreeco/swift-case-paths/pull/160#discussion_r1630303847), which I believe is not a problem.