### PR TITLE
Fix build warning when `@CasePathable` is applied to enums with no cases

### DIFF
--- a/Sources/CasePathsMacros/CasePathableMacro.swift
+++ b/Sources/CasePathsMacros/CasePathableMacro.swift
@@ -91,14 +91,14 @@ extension CasePathableMacro: MemberMacro {
       "allCasePaths.append(\\.\(raw: $0.name.text))"
     }
 
+    let subscriptReturn = allCases.isEmpty ? #"\.never"# : #"return \.never"#
+
     return [
       """
       public struct AllCasePaths: Sequence {
-      \(allCases.isEmpty ? "" : """
-        public subscript(root: \(enumName)) -> PartialCaseKeyPath<\(enumName)> {
-        \(raw: rootSubscriptCases.map { "\($0.description)\n" }.joined())return \\.never
-        }
-        """)
+      public subscript(root: \(enumName)) -> PartialCaseKeyPath<\(enumName)> {
+      \(raw: rootSubscriptCases.map { "\($0.description)\n" }.joined())\(raw: subscriptReturn)
+      }
       \(raw: casePaths.map(\.description).joined(separator: "\n"))
       public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<\(enumName)>]> {
       \(raw: allCases.isEmpty ? "let" : "var") allCasePaths: [PartialCaseKeyPath<\(enumName)>] = []\

--- a/Sources/CasePathsMacros/CasePathableMacro.swift
+++ b/Sources/CasePathsMacros/CasePathableMacro.swift
@@ -94,9 +94,11 @@ extension CasePathableMacro: MemberMacro {
     return [
       """
       public struct AllCasePaths: Sequence {
-      public subscript(root: \(enumName)) -> PartialCaseKeyPath<\(enumName)> {
-      \(raw: rootSubscriptCases.map { "\($0.description)\n" }.joined())return \\.never
-      }
+      \(allCases.isEmpty ? "" : """
+        public subscript(root: \(enumName)) -> PartialCaseKeyPath<\(enumName)> {
+        \(raw: rootSubscriptCases.map { "\($0.description)\n" }.joined())return \\.never
+        }
+        """)
       \(raw: casePaths.map(\.description).joined(separator: "\n"))
       public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<\(enumName)>]> {
       \(raw: allCases.isEmpty ? "let" : "var") allCasePaths: [PartialCaseKeyPath<\(enumName)>] = []\

--- a/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
+++ b/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
@@ -111,6 +111,31 @@ final class CasePathableMacroTests: XCTestCase {
     }
   }
 
+  func testCasePathable_NoCases() {
+    assertMacro {
+      """
+      @CasePathable enum EnumWithNoCases {}
+      """
+    } expansion: {
+      """
+      enum EnumWithNoCases {
+
+          public struct AllCasePaths: Sequence {
+
+
+              public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<EnumWithNoCases>]> {
+                  let allCasePaths: [PartialCaseKeyPath<EnumWithNoCases>] = []
+                  return allCasePaths.makeIterator()
+              }
+          }
+          public static var allCasePaths: AllCasePaths { AllCasePaths() }}
+
+      extension EnumWithNoCases: CasePaths.CasePathable {
+      }
+      """
+    }
+  }
+
   func testCasePathable_ElementList() {
     assertMacro {
       """
@@ -343,13 +368,11 @@ final class CasePathableMacroTests: XCTestCase {
       }
       """
     } expansion: {
-      #"""
+      """
       enum Foo: CasePathable {
 
           public struct AllCasePaths: Sequence {
-              public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
-                  return \.never
-              }
+
 
               public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Foo>]> {
                   let allCasePaths: [PartialCaseKeyPath<Foo>] = []
@@ -358,7 +381,7 @@ final class CasePathableMacroTests: XCTestCase {
           }
           public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
-      """#
+      """
     }
     assertMacro {
       """
@@ -366,13 +389,11 @@ final class CasePathableMacroTests: XCTestCase {
       }
       """
     } expansion: {
-      #"""
+      """
       enum Foo: CasePaths.CasePathable {
 
           public struct AllCasePaths: Sequence {
-              public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
-                  return \.never
-              }
+
 
               public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Foo>]> {
                   let allCasePaths: [PartialCaseKeyPath<Foo>] = []
@@ -381,7 +402,7 @@ final class CasePathableMacroTests: XCTestCase {
           }
           public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
-      """#
+      """
     }
   }
 

--- a/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
+++ b/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
@@ -117,11 +117,13 @@ final class CasePathableMacroTests: XCTestCase {
       @CasePathable enum EnumWithNoCases {}
       """
     } expansion: {
-      """
+      #"""
       enum EnumWithNoCases {
 
           public struct AllCasePaths: Sequence {
-
+              public subscript(root: EnumWithNoCases) -> PartialCaseKeyPath<EnumWithNoCases> {
+                  \.never
+              }
 
               public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<EnumWithNoCases>]> {
                   let allCasePaths: [PartialCaseKeyPath<EnumWithNoCases>] = []
@@ -132,7 +134,7 @@ final class CasePathableMacroTests: XCTestCase {
 
       extension EnumWithNoCases: CasePaths.CasePathable {
       }
-      """
+      """#
     }
   }
 
@@ -368,11 +370,13 @@ final class CasePathableMacroTests: XCTestCase {
       }
       """
     } expansion: {
-      """
+      #"""
       enum Foo: CasePathable {
 
           public struct AllCasePaths: Sequence {
-
+              public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
+                  \.never
+              }
 
               public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Foo>]> {
                   let allCasePaths: [PartialCaseKeyPath<Foo>] = []
@@ -381,7 +385,7 @@ final class CasePathableMacroTests: XCTestCase {
           }
           public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
-      """
+      """#
     }
     assertMacro {
       """
@@ -389,11 +393,13 @@ final class CasePathableMacroTests: XCTestCase {
       }
       """
     } expansion: {
-      """
+      #"""
       enum Foo: CasePaths.CasePathable {
 
           public struct AllCasePaths: Sequence {
-
+              public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
+                  \.never
+              }
 
               public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Foo>]> {
                   let allCasePaths: [PartialCaseKeyPath<Foo>] = []
@@ -402,7 +408,7 @@ final class CasePathableMacroTests: XCTestCase {
           }
           public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
-      """
+      """#
     }
   }
 


### PR DESCRIPTION
Fixes warnings due to unreachable code introduced in [1.4.0](https://github.com/pointfreeco/swift-case-paths/releases/tag/1.4.0):

For example:

```swift
@CasePathable enum Foo {}
```

Produces this expansion (compiler warnings added as code comments by me)

```swift
enum Foo: CasePathable {
  public struct AllCasePaths: Sequence {
    public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
      return \.never // ⚠️ warning: will never be executed
      // 'root' is of type 'Foo' which cannot be constructed because it
      // is an enum with no cases
    }

    public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Foo>]> {
      let allCasePaths: [PartialCaseKeyPath<Foo>] = []
      return allCasePaths.makeIterator()
    }
  }
  public static var allCasePaths: AllCasePaths { AllCasePaths() }
}
```

We can fix this warning by simply not producing the subscript definition when the enum has no cases.