### PR TITLE
Make `Optional`/`Result` more consistent with macro-generated code

### DIFF
--- a/Sources/CasePaths/Optional+CasePathable.swift
+++ b/Sources/CasePaths/Optional+CasePathable.swift
@@ -47,11 +47,6 @@ extension Optional: CasePathable {
         }
       )
     }
-
-    private let _allCasePaths: [PartialCaseKeyPath<Optional>] = [
-      \.none,
-      \.some,
-    ]
   }
 
   public static var allCasePaths: AllCasePaths {
@@ -75,6 +70,6 @@ extension Case {
 
 extension Optional.AllCasePaths: Sequence {
   public func makeIterator() -> some IteratorProtocol<PartialCaseKeyPath<Optional>> {
-    _allCasePaths.makeIterator()
+    [\.none, \.some].makeIterator()
   }
 }

--- a/Sources/CasePaths/Result+CasePathable.swift
+++ b/Sources/CasePaths/Result+CasePathable.swift
@@ -29,11 +29,6 @@ extension Result: CasePathable {
         }
       )
     }
-
-    private let _allCasePaths: [PartialCaseKeyPath<Result>] = [
-      \.success,
-      \.failure,
-    ]
   }
 
   public static var allCasePaths: AllCasePaths {
@@ -43,6 +38,6 @@ extension Result: CasePathable {
 
 extension Result.AllCasePaths: Sequence {
   public func makeIterator() -> some IteratorProtocol<PartialCaseKeyPath<Result>> {
-    _allCasePaths.makeIterator()
+    [\.success, \.failure].makeIterator()
   }
 }


### PR DESCRIPTION
This just cleans up the case path iteration for optional/result to be more consistent with the macro, which doesn't hold onto the array as storage, but rather lazily creates it.