### PR TITLE
Add `CasePathIterable` and `CasePathReflectable` protocols 

### DIFF
--- a/Sources/CasePaths/CasePathIterable.swift
+++ b/Sources/CasePaths/CasePathIterable.swift
@@ -1,0 +1,2 @@
+public protocol CasePathIterable: CasePathable
+where AllCasePaths: Sequence, AllCasePaths.Element == PartialCaseKeyPath<Self> {}

--- a/Sources/CasePaths/CasePathIterable.swift
+++ b/Sources/CasePaths/CasePathIterable.swift
@@ -1,2 +1,17 @@
+/// A type that provides a collection of all of its case paths.
+///
+/// The ``CasePathable()`` macro automatically generates a conformance to this protocol.
+///
+/// You can iterate over ``CasePathable/allCasePaths`` to get access to each individual case path:
+///
+/// ```swift
+/// @CasePathable enum Field {
+///   case title(String)
+///   case body(String
+///   case isLive
+/// }
+///
+/// Array(Field.allCasePaths)  // [\.title, \.body, \.isLive]
+/// ```
 public protocol CasePathIterable: CasePathable
 where AllCasePaths: Sequence, AllCasePaths.Element == PartialCaseKeyPath<Self> {}

--- a/Sources/CasePaths/CasePathReflectable.swift
+++ b/Sources/CasePaths/CasePathReflectable.swift
@@ -1,4 +1,27 @@
+/// A type that can reflect a case path from a given case.
+///
+/// The ``CasePathable()`` macro automatically generates a conformance to this protocol on the
+/// enum's ``CasePathable/AllCasePaths`` type.
+///
+/// You can look up an enum's case path by passing it to ``subscript(root:)``:
+///
+/// ```swift
+/// @CasePathable
+/// enum Field {
+///   case title(String)
+///   case body(String)
+///   case isLive
+/// }
+///
+/// Field.allCasePaths[.title("Hello, Blob!")]  // \.title
+/// ```
 public protocol CasePathReflectable<Root> {
+  /// The enum type that can be reflected.
   associatedtype Root: CasePathable
+
+  /// Returns the case key path for a given root value.
+  ///
+  /// - Parameter root: An root value.
+  /// - Returns: A case path to the root value.
   subscript(root: Root) -> PartialCaseKeyPath<Root> { get }
 }

--- a/Sources/CasePaths/CasePathReflectable.swift
+++ b/Sources/CasePaths/CasePathReflectable.swift
@@ -1,0 +1,4 @@
+public protocol CasePathReflectable<Root> {
+  associatedtype Root: CasePathable
+  subscript(root: Root) -> PartialCaseKeyPath<Root> { get }
+}

--- a/Sources/CasePaths/Documentation.docc/CasePathable.md
+++ b/Sources/CasePaths/Documentation.docc/CasePathable.md
@@ -18,6 +18,11 @@
 - ``subscript(dynamicMember:)-7ik0u``
 - ``subscript(dynamicMember:)-7sz4x``
 
+### Iteration and reflection
+
+- ``CasePathIterable``
+- ``CasePathReflectable``
+
 ### Manual conformances
 
 - ``AllCasePaths``

--- a/Sources/CasePaths/Macros.swift
+++ b/Sources/CasePaths/Macros.swift
@@ -25,7 +25,7 @@
 /// \UserAction.Cases.home      // CasePath<UserAction, HomeAction>
 /// \UserAction.Cases.settings  // CasePath<UserAction, SettingsAction>
 /// ```
-@attached(extension, conformances: CasePathable)
+@attached(extension, conformances: CasePathable, CasePathIterable)
 @attached(member, names: named(AllCasePaths), named(allCasePaths))
 public macro CasePathable() =
   #externalMacro(

--- a/Sources/CasePaths/Never+CasePathable.swift
+++ b/Sources/CasePaths/Never+CasePathable.swift
@@ -1,6 +1,5 @@
-extension Never: CasePathable {
-  public struct AllCasePaths: Sendable {
-    /// Returns the case key path for a given root value.
+extension Never: CasePathable, CasePathIterable {
+  public struct AllCasePaths: CasePathReflectable, Sendable {
     public subscript(root: Never) -> PartialCaseKeyPath<Never> {
       \.never
     }

--- a/Sources/CasePaths/Optional+CasePathable.swift
+++ b/Sources/CasePaths/Optional+CasePathable.swift
@@ -1,7 +1,6 @@
-extension Optional: CasePathable {
+extension Optional: CasePathable, CasePathIterable {
   @dynamicMemberLookup
-  public struct AllCasePaths: Sendable {
-    /// Returns the case key path for a given root value.
+  public struct AllCasePaths: CasePathReflectable, Sendable {
     public subscript(root: Optional) -> PartialCaseKeyPath<Optional> {
       switch root {
       case .none: return \.none

--- a/Sources/CasePaths/Result+CasePathable.swift
+++ b/Sources/CasePaths/Result+CasePathable.swift
@@ -1,6 +1,5 @@
-extension Result: CasePathable {
-  public struct AllCasePaths: Sendable {
-    /// Returns the case key path for a given root value.
+extension Result: CasePathable, CasePathIterable {
+  public struct AllCasePaths: CasePathReflectable, Sendable {
     public subscript(root: Result) -> PartialCaseKeyPath<Result> {
       switch root {
       case .success: return \.success

--- a/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
+++ b/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
@@ -31,7 +31,7 @@ final class CasePathableMacroTests: XCTestCase {
         case fizz(buzz: String)
         case fizzier(Int, buzzier: String)
 
-        public struct AllCasePaths: Sendable, Sequence {
+        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
           public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
@@ -111,7 +111,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      extension Foo: CasePaths.CasePathable {
+      extension Foo: CasePathable, CasePathIterable {
       }
       """#
     }
@@ -126,7 +126,7 @@ final class CasePathableMacroTests: XCTestCase {
       #"""
       enum EnumWithNoCases {
 
-          public struct AllCasePaths: Sendable, Sequence {
+          public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
               public subscript(root: EnumWithNoCases) -> PartialCaseKeyPath<EnumWithNoCases> {
                   \.never
               }
@@ -138,7 +138,7 @@ final class CasePathableMacroTests: XCTestCase {
           }
           public static var allCasePaths: AllCasePaths { AllCasePaths() }}
 
-      extension EnumWithNoCases: CasePaths.CasePathable {
+      extension EnumWithNoCases: CasePathable, CasePathIterable {
       }
       """#
     }
@@ -156,7 +156,7 @@ final class CasePathableMacroTests: XCTestCase {
       public enum Foo {
         case bar(Int), baz(String)
 
-        public struct AllCasePaths: Sendable, Sequence {
+        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
           public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
@@ -202,7 +202,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      extension Foo: CasePaths.CasePathable {
+      extension Foo: CasePathable, CasePathIterable {
       }
       """#
     }
@@ -220,7 +220,7 @@ final class CasePathableMacroTests: XCTestCase {
       public enum Foo {
         case bar(Int)
 
-        public struct AllCasePaths: Sendable, Sequence {
+        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
           public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
@@ -249,7 +249,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      extension Foo: CasePaths.CasePathable {
+      extension Foo: CasePathable, CasePathIterable {
       }
       """#
     }
@@ -264,7 +264,7 @@ final class CasePathableMacroTests: XCTestCase {
       package enum Foo {
         case bar(Int)
 
-        public struct AllCasePaths: Sendable, Sequence {
+        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
           public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
@@ -293,7 +293,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      extension Foo: CasePaths.CasePathable {
+      extension Foo: CasePathable, CasePathIterable {
       }
       """#
     }
@@ -308,7 +308,7 @@ final class CasePathableMacroTests: XCTestCase {
       private enum Foo {
         case bar(Int)
 
-        public struct AllCasePaths: Sendable, Sequence {
+        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
           public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
@@ -337,7 +337,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      extension Foo: CasePaths.CasePathable {
+      extension Foo: CasePathable, CasePathIterable {
       }
       """#
     }
@@ -389,7 +389,7 @@ final class CasePathableMacroTests: XCTestCase {
       #"""
       enum Foo: CasePathable {
 
-          public struct AllCasePaths: Sendable, Sequence {
+          public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
               public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
                   \.never
               }
@@ -400,6 +400,9 @@ final class CasePathableMacroTests: XCTestCase {
               }
           }
           public static var allCasePaths: AllCasePaths { AllCasePaths() }
+      }
+
+      extension Foo: CasePaths.CasePathIterable {
       }
       """#
     }
@@ -412,7 +415,7 @@ final class CasePathableMacroTests: XCTestCase {
       #"""
       enum Foo: CasePaths.CasePathable {
 
-          public struct AllCasePaths: Sendable, Sequence {
+          public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
               public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
                   \.never
               }
@@ -423,6 +426,9 @@ final class CasePathableMacroTests: XCTestCase {
               }
           }
           public static var allCasePaths: AllCasePaths { AllCasePaths() }
+      }
+
+      extension Foo: CasePaths.CasePathIterable {
       }
       """#
     }
@@ -440,7 +446,7 @@ final class CasePathableMacroTests: XCTestCase {
       enum Foo {
         case bar(_ int: Int, _ bool: Bool)
 
-        public struct AllCasePaths: Sendable, Sequence {
+        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
           public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
@@ -469,7 +475,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      extension Foo: CasePaths.CasePathable {
+      extension Foo: CasePathable, CasePathIterable {
       }
       """#
     }
@@ -487,7 +493,7 @@ final class CasePathableMacroTests: XCTestCase {
       enum Foo {
         case bar(Bar<Self>)
 
-        public struct AllCasePaths: Sendable, Sequence {
+        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
           public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
@@ -516,7 +522,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      extension Foo: CasePaths.CasePathable {
+      extension Foo: CasePathable, CasePathIterable {
       }
       """#
     }
@@ -534,7 +540,7 @@ final class CasePathableMacroTests: XCTestCase {
       enum Foo {
         case bar(int: Int = 42, bool: Bool = true)
 
-        public struct AllCasePaths: Sendable, Sequence {
+        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
           public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
@@ -563,7 +569,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      extension Foo: CasePaths.CasePathable {
+      extension Foo: CasePathable, CasePathIterable {
       }
       """#
     }
@@ -615,7 +621,7 @@ final class CasePathableMacroTests: XCTestCase {
         #endif
         #endif
 
-        public struct AllCasePaths: Sendable, Sequence {
+        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
           public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
@@ -787,7 +793,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      extension Foo: CasePaths.CasePathable {
+      extension Foo: CasePathable, CasePathIterable {
       }
       """#
     }
@@ -808,7 +814,7 @@ final class CasePathableMacroTests: XCTestCase {
       enum Foo {
         case bar
 
-        public struct AllCasePaths: Sendable, Sequence {
+        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
           public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
@@ -837,7 +843,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      @available(iOS, unavailable) extension Foo: CasePaths.CasePathable {
+      @available(iOS, unavailable) extension Foo: CasePathable, CasePathIterable {
       }
       """#
     }
@@ -884,7 +890,7 @@ final class CasePathableMacroTests: XCTestCase {
          */
         case fizz, buzz
 
-        public struct AllCasePaths: Sendable, Sequence {
+        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
           public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
@@ -978,7 +984,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      extension Foo: CasePaths.CasePathable {
+      extension Foo: CasePathable, CasePathIterable {
       }
       """#
     }
@@ -1001,7 +1007,7 @@ final class CasePathableMacroTests: XCTestCase {
       // case foo
         case bar
 
-        public struct AllCasePaths: Sendable, Sequence {
+        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
           public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
@@ -1032,7 +1038,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      extension Foo: CasePaths.CasePathable {
+      extension Foo: CasePathable, CasePathIterable {
       }
       """#
     }
@@ -1060,7 +1066,7 @@ final class CasePathableMacroTests: XCTestCase {
         case fizzier/*Comment in case*/(Int, buzzier: String)
         case fizziest // Comment without associated value
 
-        public struct AllCasePaths: Sendable, Sequence {
+        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
           public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
@@ -1158,7 +1164,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      extension Foo: CasePaths.CasePathable {
+      extension Foo: CasePathable, CasePathIterable {
       }
       """#
     }

--- a/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
+++ b/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
@@ -31,8 +31,8 @@ final class CasePathableMacroTests: XCTestCase {
         case fizz(buzz: String)
         case fizzier(Int, buzzier: String)
 
-        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
-          public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
+        public struct AllCasePaths: CasePaths.CasePathReflectable, Sendable, Sequence {
+          public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
             }
@@ -99,8 +99,8 @@ final class CasePathableMacroTests: XCTestCase {
               }
             )
           }
-          public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Foo>]> {
-            var allCasePaths: [PartialCaseKeyPath<Foo>] = []
+          public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
             allCasePaths.append(\.bar)
             allCasePaths.append(\.baz)
             allCasePaths.append(\.fizz)
@@ -111,7 +111,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      extension Foo: CasePathable, CasePathIterable {
+      extension Foo: CasePaths.CasePathable, CasePaths.CasePathIterable {
       }
       """#
     }
@@ -126,19 +126,19 @@ final class CasePathableMacroTests: XCTestCase {
       #"""
       enum EnumWithNoCases {
 
-          public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
-              public subscript(root: EnumWithNoCases) -> PartialCaseKeyPath<EnumWithNoCases> {
+          public struct AllCasePaths: CasePaths.CasePathReflectable, Sendable, Sequence {
+              public subscript(root: EnumWithNoCases) -> CasePaths.PartialCaseKeyPath<EnumWithNoCases> {
                   \.never
               }
 
-              public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<EnumWithNoCases>]> {
-                  let allCasePaths: [PartialCaseKeyPath<EnumWithNoCases>] = []
+              public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<EnumWithNoCases>]> {
+                  let allCasePaths: [CasePaths.PartialCaseKeyPath<EnumWithNoCases>] = []
                   return allCasePaths.makeIterator()
               }
           }
           public static var allCasePaths: AllCasePaths { AllCasePaths() }}
 
-      extension EnumWithNoCases: CasePathable, CasePathIterable {
+      extension EnumWithNoCases: CasePaths.CasePathable, CasePaths.CasePathIterable {
       }
       """#
     }
@@ -156,8 +156,8 @@ final class CasePathableMacroTests: XCTestCase {
       public enum Foo {
         case bar(Int), baz(String)
 
-        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
-          public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
+        public struct AllCasePaths: CasePaths.CasePathReflectable, Sendable, Sequence {
+          public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
             }
@@ -192,8 +192,8 @@ final class CasePathableMacroTests: XCTestCase {
               }
             )
           }
-          public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Foo>]> {
-            var allCasePaths: [PartialCaseKeyPath<Foo>] = []
+          public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
             allCasePaths.append(\.bar)
             allCasePaths.append(\.baz)
             return allCasePaths.makeIterator()
@@ -202,7 +202,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      extension Foo: CasePathable, CasePathIterable {
+      extension Foo: CasePaths.CasePathable, CasePaths.CasePathIterable {
       }
       """#
     }
@@ -220,8 +220,8 @@ final class CasePathableMacroTests: XCTestCase {
       public enum Foo {
         case bar(Int)
 
-        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
-          public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
+        public struct AllCasePaths: CasePaths.CasePathReflectable, Sendable, Sequence {
+          public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
             }
@@ -240,8 +240,8 @@ final class CasePathableMacroTests: XCTestCase {
               }
             )
           }
-          public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Foo>]> {
-            var allCasePaths: [PartialCaseKeyPath<Foo>] = []
+          public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
             allCasePaths.append(\.bar)
             return allCasePaths.makeIterator()
           }
@@ -249,7 +249,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      extension Foo: CasePathable, CasePathIterable {
+      extension Foo: CasePaths.CasePathable, CasePaths.CasePathIterable {
       }
       """#
     }
@@ -264,8 +264,8 @@ final class CasePathableMacroTests: XCTestCase {
       package enum Foo {
         case bar(Int)
 
-        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
-          public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
+        public struct AllCasePaths: CasePaths.CasePathReflectable, Sendable, Sequence {
+          public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
             }
@@ -284,8 +284,8 @@ final class CasePathableMacroTests: XCTestCase {
               }
             )
           }
-          public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Foo>]> {
-            var allCasePaths: [PartialCaseKeyPath<Foo>] = []
+          public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
             allCasePaths.append(\.bar)
             return allCasePaths.makeIterator()
           }
@@ -293,7 +293,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      extension Foo: CasePathable, CasePathIterable {
+      extension Foo: CasePaths.CasePathable, CasePaths.CasePathIterable {
       }
       """#
     }
@@ -308,8 +308,8 @@ final class CasePathableMacroTests: XCTestCase {
       private enum Foo {
         case bar(Int)
 
-        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
-          public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
+        public struct AllCasePaths: CasePaths.CasePathReflectable, Sendable, Sequence {
+          public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
             }
@@ -328,8 +328,8 @@ final class CasePathableMacroTests: XCTestCase {
               }
             )
           }
-          public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Foo>]> {
-            var allCasePaths: [PartialCaseKeyPath<Foo>] = []
+          public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
             allCasePaths.append(\.bar)
             return allCasePaths.makeIterator()
           }
@@ -337,7 +337,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      extension Foo: CasePathable, CasePathIterable {
+      extension Foo: CasePaths.CasePathable, CasePaths.CasePathIterable {
       }
       """#
     }
@@ -389,13 +389,13 @@ final class CasePathableMacroTests: XCTestCase {
       #"""
       enum Foo: CasePathable {
 
-          public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
-              public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
+          public struct AllCasePaths: CasePaths.CasePathReflectable, Sendable, Sequence {
+              public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
                   \.never
               }
 
-              public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Foo>]> {
-                  let allCasePaths: [PartialCaseKeyPath<Foo>] = []
+              public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+                  let allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
                   return allCasePaths.makeIterator()
               }
           }
@@ -415,13 +415,13 @@ final class CasePathableMacroTests: XCTestCase {
       #"""
       enum Foo: CasePaths.CasePathable {
 
-          public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
-              public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
+          public struct AllCasePaths: CasePaths.CasePathReflectable, Sendable, Sequence {
+              public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
                   \.never
               }
 
-              public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Foo>]> {
-                  let allCasePaths: [PartialCaseKeyPath<Foo>] = []
+              public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+                  let allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
                   return allCasePaths.makeIterator()
               }
           }
@@ -446,8 +446,8 @@ final class CasePathableMacroTests: XCTestCase {
       enum Foo {
         case bar(_ int: Int, _ bool: Bool)
 
-        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
-          public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
+        public struct AllCasePaths: CasePaths.CasePathReflectable, Sendable, Sequence {
+          public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
             }
@@ -466,8 +466,8 @@ final class CasePathableMacroTests: XCTestCase {
               }
             )
           }
-          public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Foo>]> {
-            var allCasePaths: [PartialCaseKeyPath<Foo>] = []
+          public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
             allCasePaths.append(\.bar)
             return allCasePaths.makeIterator()
           }
@@ -475,7 +475,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      extension Foo: CasePathable, CasePathIterable {
+      extension Foo: CasePaths.CasePathable, CasePaths.CasePathIterable {
       }
       """#
     }
@@ -493,8 +493,8 @@ final class CasePathableMacroTests: XCTestCase {
       enum Foo {
         case bar(Bar<Self>)
 
-        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
-          public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
+        public struct AllCasePaths: CasePaths.CasePathReflectable, Sendable, Sequence {
+          public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
             }
@@ -513,8 +513,8 @@ final class CasePathableMacroTests: XCTestCase {
               }
             )
           }
-          public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Foo>]> {
-            var allCasePaths: [PartialCaseKeyPath<Foo>] = []
+          public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
             allCasePaths.append(\.bar)
             return allCasePaths.makeIterator()
           }
@@ -522,7 +522,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      extension Foo: CasePathable, CasePathIterable {
+      extension Foo: CasePaths.CasePathable, CasePaths.CasePathIterable {
       }
       """#
     }
@@ -540,8 +540,8 @@ final class CasePathableMacroTests: XCTestCase {
       enum Foo {
         case bar(int: Int = 42, bool: Bool = true)
 
-        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
-          public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
+        public struct AllCasePaths: CasePaths.CasePathReflectable, Sendable, Sequence {
+          public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
             }
@@ -560,8 +560,8 @@ final class CasePathableMacroTests: XCTestCase {
               }
             )
           }
-          public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Foo>]> {
-            var allCasePaths: [PartialCaseKeyPath<Foo>] = []
+          public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
             allCasePaths.append(\.bar)
             return allCasePaths.makeIterator()
           }
@@ -569,7 +569,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      extension Foo: CasePathable, CasePathIterable {
+      extension Foo: CasePaths.CasePathable, CasePaths.CasePathIterable {
       }
       """#
     }
@@ -621,8 +621,8 @@ final class CasePathableMacroTests: XCTestCase {
         #endif
         #endif
 
-        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
-          public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
+        public struct AllCasePaths: CasePaths.CasePathReflectable, Sendable, Sequence {
+          public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
             }
@@ -769,8 +769,8 @@ final class CasePathableMacroTests: XCTestCase {
           }
           #endif
           #endif
-          public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Foo>]> {
-            var allCasePaths: [PartialCaseKeyPath<Foo>] = []
+          public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
             allCasePaths.append(\.bar)
             #if os(macOS)
             allCasePaths.append(\.macCase)
@@ -793,7 +793,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      extension Foo: CasePathable, CasePathIterable {
+      extension Foo: CasePaths.CasePathable, CasePaths.CasePathIterable {
       }
       """#
     }
@@ -814,8 +814,8 @@ final class CasePathableMacroTests: XCTestCase {
       enum Foo {
         case bar
 
-        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
-          public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
+        public struct AllCasePaths: CasePaths.CasePathReflectable, Sendable, Sequence {
+          public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
             }
@@ -834,8 +834,8 @@ final class CasePathableMacroTests: XCTestCase {
               }
             )
           }
-          public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Foo>]> {
-            var allCasePaths: [PartialCaseKeyPath<Foo>] = []
+          public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
             allCasePaths.append(\.bar)
             return allCasePaths.makeIterator()
           }
@@ -843,7 +843,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      @available(iOS, unavailable) extension Foo: CasePathable, CasePathIterable {
+      @available(iOS, unavailable) extension Foo: CasePaths.CasePathable, CasePaths.CasePathIterable {
       }
       """#
     }
@@ -890,8 +890,8 @@ final class CasePathableMacroTests: XCTestCase {
          */
         case fizz, buzz
 
-        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
-          public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
+        public struct AllCasePaths: CasePaths.CasePathReflectable, Sendable, Sequence {
+          public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
             }
@@ -972,8 +972,8 @@ final class CasePathableMacroTests: XCTestCase {
               }
             )
           }
-          public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Foo>]> {
-            var allCasePaths: [PartialCaseKeyPath<Foo>] = []
+          public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
             allCasePaths.append(\.bar)
             allCasePaths.append(\.baz)
             allCasePaths.append(\.fizz)
@@ -984,7 +984,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      extension Foo: CasePathable, CasePathIterable {
+      extension Foo: CasePaths.CasePathable, CasePaths.CasePathIterable {
       }
       """#
     }
@@ -1007,8 +1007,8 @@ final class CasePathableMacroTests: XCTestCase {
       // case foo
         case bar
 
-        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
-          public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
+        public struct AllCasePaths: CasePaths.CasePathReflectable, Sendable, Sequence {
+          public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
             }
@@ -1029,8 +1029,8 @@ final class CasePathableMacroTests: XCTestCase {
               }
             )
           }
-          public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Foo>]> {
-            var allCasePaths: [PartialCaseKeyPath<Foo>] = []
+          public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
             allCasePaths.append(\.bar)
             return allCasePaths.makeIterator()
           }
@@ -1038,7 +1038,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      extension Foo: CasePathable, CasePathIterable {
+      extension Foo: CasePaths.CasePathable, CasePaths.CasePathIterable {
       }
       """#
     }
@@ -1066,8 +1066,8 @@ final class CasePathableMacroTests: XCTestCase {
         case fizzier/*Comment in case*/(Int, buzzier: String)
         case fizziest // Comment without associated value
 
-        public struct AllCasePaths: CasePathReflectable, Hashable, Sendable, Sequence {
-          public subscript(root: Foo) -> PartialCaseKeyPath<Foo> {
+        public struct AllCasePaths: CasePaths.CasePathReflectable, Sendable, Sequence {
+          public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
             if root.is(\.bar) {
               return \.bar
             }
@@ -1151,8 +1151,8 @@ final class CasePathableMacroTests: XCTestCase {
               }
             )
           }
-          public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Foo>]> {
-            var allCasePaths: [PartialCaseKeyPath<Foo>] = []
+          public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
             allCasePaths.append(\.bar)
             allCasePaths.append(\.baz)
             allCasePaths.append(\.fizz)
@@ -1164,7 +1164,7 @@ final class CasePathableMacroTests: XCTestCase {
         public static var allCasePaths: AllCasePaths { AllCasePaths() }
       }
 
-      extension Foo: CasePathable, CasePathIterable {
+      extension Foo: CasePaths.CasePathable, CasePaths.CasePathIterable {
       }
       """#
     }

--- a/Tests/CasePathsTests/CaseSetTests.swift
+++ b/Tests/CasePathsTests/CaseSetTests.swift
@@ -1,0 +1,62 @@
+#if swift(>=6)
+  import CasePaths
+  import Testing
+
+  @dynamicMemberLookup
+  public struct CaseSet<Root: CasePathable>: Sequence {
+    private var storage: [PartialCaseKeyPath<Root> & Sendable: Root] = [:]
+
+    public init() {}
+
+    public init(_ elements: some Collection<Root>)
+    where Root.AllCasePaths: CasePathReflectable<Root> {
+      self.storage = [PartialCaseKeyPath<Root> & Sendable: Root](
+        uniqueKeysWithValues: elements.map { (Root.allCasePaths[$0], $0) }
+      )
+    }
+
+    public subscript<Member>(
+      dynamicMember keyPath: CaseKeyPath<Root, Member> & Sendable
+    ) -> Member? {
+      get { storage[keyPath].flatMap { $0[case: keyPath] } }
+      set { storage[keyPath] = newValue.map(keyPath.callAsFunction) }
+    }
+
+    public subscript(
+      dynamicMember keyPath: CaseKeyPath<Root, Void> & Sendable
+    ) -> Bool {
+      get { storage[keyPath].flatMap { $0[case: keyPath] } != nil }
+      set { storage[keyPath] = newValue ? keyPath() : nil }
+    }
+
+    public func makeIterator() -> some IteratorProtocol<Root> {
+      storage.values.makeIterator()
+    }
+  }
+
+  extension CaseSet: Equatable where Root: Equatable {}
+  extension CaseSet: Hashable where Root: Hashable {}
+  extension CaseSet: Sendable where Root: Sendable {}
+
+  extension CaseSet: ExpressibleByArrayLiteral where Root.AllCasePaths: CasePathReflectable<Root> {
+    public init(arrayLiteral elements: Root...) {
+      self.init(elements)
+    }
+  }
+
+  @CasePathable private enum Post {
+    case title(String)
+    case body(String)
+    case isHidden
+  }
+
+  @Test private func caseSet() {
+    var set: CaseSet<Post> = [.title("Hello")]
+    set.body = "World"
+    set.isHidden = true
+
+    #expect(set.title == "Hello")
+    #expect(set.body == "World")
+    #expect(set.isHidden)
+  }
+#endif


### PR DESCRIPTION
While the macro recently introduced iteration (https://github.com/pointfreeco/swift-case-paths/pull/159) and "reflection" (https://github.com/pointfreeco/swift-case-paths/pull/158), there's no way to abstract over it. Adding it directly to the `CasePathable` protocol would be potentially source breaking, so instead we can introduce some new protocols.