### PR TITLE
Point to `swiftlang/swift-syntax`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax", "509.0.0"..<"601.0.0-prerelease"),
+    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"601.0.0-prerelease"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.0.0"),
   ],

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -18,7 +18,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax", "509.0.0"..<"601.0.0-prerelease"),
+    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"601.0.0-prerelease"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.2.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.0.0"),
   ],


### PR DESCRIPTION
The repo has been moved to the new `swiftlang` org. This fixes warnings when using other dependencies that already have an updated reference:

<img width="1175" alt="Screenshot 2024-07-08 at 09 06 36" src="https://github.com/pointfreeco/swift-case-paths/assets/685609/a3f722bb-243a-4284-939f-271d58d946a9">
