### PR TITLE
Disable sendable dynamic key path lookup for now

### DIFF
--- a/Sources/CasePaths/CasePathable.swift
+++ b/Sources/CasePaths/CasePathable.swift
@@ -69,18 +69,18 @@ extension Case {
     self = Case<Root>()[keyPath: keyPath]
   }
 
-  #if swift(>=6)
-    public subscript<AppendedValue>(
-      dynamicMember keyPath: KeyPath<Value.AllCasePaths, AnyCasePath<Value, AppendedValue>>
-        & Sendable
-    ) -> Case<AppendedValue>
-    where Value: CasePathable {
-      Case<AppendedValue>(
-        embed: { embed(Value.allCasePaths[keyPath: keyPath].embed($0)) },
-        extract: { extract(from: $0).flatMap(Value.allCasePaths[keyPath: keyPath].extract) }
-      )
-    }
-  #else
+  // #if swift(>=6)
+  //   public subscript<AppendedValue>(
+  //     dynamicMember keyPath: KeyPath<Value.AllCasePaths, AnyCasePath<Value, AppendedValue>>
+  //       & Sendable
+  //   ) -> Case<AppendedValue>
+  //   where Value: CasePathable {
+  //     Case<AppendedValue>(
+  //       embed: { embed(Value.allCasePaths[keyPath: keyPath].embed($0)) },
+  //       extract: { extract(from: $0).flatMap(Value.allCasePaths[keyPath: keyPath].extract) }
+  //     )
+  //   }
+  // #else
     public subscript<AppendedValue>(
       dynamicMember keyPath: KeyPath<Value.AllCasePaths, AnyCasePath<Value, AppendedValue>>
     ) -> Case<AppendedValue>
@@ -95,7 +95,7 @@ extension Case {
         }
       )
     }
-  #endif
+  // #endif
 
   public func embed(_ value: Value) -> Any {
     self._embed(value)
@@ -513,25 +513,25 @@ extension AnyCasePath {
 }
 
 extension AnyCasePath where Value: CasePathable {
-  #if swift(>=6)
-    /// Returns a new case path created by appending the case path at the given key path to this one.
-    ///
-    /// This subscript is automatically invoked by case key path expressions via dynamic member
-    /// lookup, and should not be invoked directly.
-    ///
-    /// - Parameter keyPath: A key path to a case-pathable case path.
-    public subscript<AppendedValue>(
-      dynamicMember keyPath: KeyPath<Value.AllCasePaths, AnyCasePath<Value, AppendedValue>>
-        & Sendable
-    ) -> AnyCasePath<Root, AppendedValue> {
-      AnyCasePath<Root, AppendedValue>(
-        embed: { self.embed(Value.allCasePaths[keyPath: keyPath].embed($0)) },
-        extract: {
-          self.extract(from: $0).flatMap(Value.allCasePaths[keyPath: keyPath].extract(from:))
-        }
-      )
-    }
-  #else
+  // #if swift(>=6)
+  //   /// Returns a new case path created by appending the case path at the given key path to this one.
+  //   ///
+  //   /// This subscript is automatically invoked by case key path expressions via dynamic member
+  //   /// lookup, and should not be invoked directly.
+  //   ///
+  //   /// - Parameter keyPath: A key path to a case-pathable case path.
+  //   public subscript<AppendedValue>(
+  //     dynamicMember keyPath: KeyPath<Value.AllCasePaths, AnyCasePath<Value, AppendedValue>>
+  //       & Sendable
+  //   ) -> AnyCasePath<Root, AppendedValue> {
+  //     AnyCasePath<Root, AppendedValue>(
+  //       embed: { self.embed(Value.allCasePaths[keyPath: keyPath].embed($0)) },
+  //       extract: {
+  //         self.extract(from: $0).flatMap(Value.allCasePaths[keyPath: keyPath].extract(from:))
+  //       }
+  //     )
+  //   }
+  // #else
     /// Returns a new case path created by appending the case path at the given key path to this one.
     ///
     /// This subscript is automatically invoked by case key path expressions via dynamic member
@@ -553,5 +553,5 @@ extension AnyCasePath where Value: CasePathable {
         }
       )
     }
-  #endif
+  // #endif
 }

--- a/Sources/CasePaths/Optional+CasePathable.swift
+++ b/Sources/CasePaths/Optional+CasePathable.swift
@@ -54,19 +54,19 @@ extension Optional: CasePathable, CasePathIterable {
 }
 
 extension Case {
-  #if swift(>=6)
-    /// A case path to the presence of a nested value.
-    ///
-    /// This subscript can chain into an optional's wrapped value without explicitly specifying each
-    /// `some` component.
-    @_disfavoredOverload
-    public subscript<Member>(
-      dynamicMember keyPath: KeyPath<Value.AllCasePaths, AnyCasePath<Value, Member?>> & Sendable
-    ) -> Case<Member>
-    where Value: CasePathable {
-      self[dynamicMember: keyPath].some
-    }
-  #else
+  // #if swift(>=6)
+  //   /// A case path to the presence of a nested value.
+  //   ///
+  //   /// This subscript can chain into an optional's wrapped value without explicitly specifying each
+  //   /// `some` component.
+  //   @_disfavoredOverload
+  //   public subscript<Member>(
+  //     dynamicMember keyPath: KeyPath<Value.AllCasePaths, AnyCasePath<Value, Member?>> & Sendable
+  //   ) -> Case<Member>
+  //   where Value: CasePathable {
+  //     self[dynamicMember: keyPath].some
+  //   }
+  // #else
     /// A case path to the presence of a nested value.
     ///
     /// This subscript can chain into an optional's wrapped value without explicitly specifying each
@@ -78,7 +78,7 @@ extension Case {
     where Value: CasePathable {
       self[dynamicMember: keyPath].some
     }
-  #endif
+  // #endif
 }
 
 extension Optional.AllCasePaths: Sequence {


### PR DESCRIPTION
A regression in recent snapshots is causing compiler crashes.

https://github.com/swiftlang/swift/issues/75244

Let's disable these code paths for now while we wait for resolution.