### PR TITLE
Use Point-Free syntax to avoid uninhabited warnings

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "3d328f4026180c11b6db1deaf769a73f5fc3faecfeedf66c827e18b20c03a2de",
   "pins" : [
     {
       "identity" : "swift-docc-plugin",
@@ -56,5 +55,5 @@
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "3d328f4026180c11b6db1deaf769a73f5fc3faecfeedf66c827e18b20c03a2de",
   "pins" : [
     {
       "identity" : "swift-docc-plugin",
@@ -23,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-macro-testing",
       "state" : {
-        "revision" : "5c4a1b9d7c23cd5c08ea50677d8e89080365cb00",
-        "version" : "0.4.0"
+        "revision" : "a35257b7e9ce44e92636447003a8eeefb77b145c",
+        "version" : "0.5.1"
       }
     },
     {
@@ -32,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "625ccca8570773dd84a34ee51a81aa2bc5a4f97a",
-        "version" : "1.16.0"
+        "revision" : "c097f955b4e724690f0fc8ffb7a6d4b881c9c4e3",
+        "version" : "1.17.2"
       }
     },
     {
@@ -41,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
-        "version" : "510.0.2"
+        "revision" : "4c6cc0a3b9e8f14b3ae2307c5ccae4de6167ac2c",
+        "version" : "600.0.0-prerelease-2024-06-12"
       }
     },
     {
@@ -55,5 +56,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Sources/CasePaths/AnyCasePath.swift
+++ b/Sources/CasePaths/AnyCasePath.swift
@@ -23,6 +23,14 @@ public struct AnyCasePath<Root, Value>: Sendable {
     self._extract = extract
   }
 
+  public static func _$embed(
+    _ embed: @escaping (Value) -> Root,
+    extract: @escaping @Sendable (Root) -> Value?
+  ) -> Self {
+    @UncheckedSendable var embed = embed
+    return Self(embed: { [$embed] in $embed.wrappedValue($0) }, extract: extract)
+  }
+
   /// Returns a root by embedding a value.
   ///
   /// - Parameter value: A value to embed.

--- a/Sources/CasePaths/AnyCasePath.swift
+++ b/Sources/CasePaths/AnyCasePath.swift
@@ -27,8 +27,13 @@ public struct AnyCasePath<Root, Value>: Sendable {
     _ embed: @escaping (Value) -> Root,
     extract: @escaping @Sendable (Root) -> Value?
   ) -> Self {
-    @UncheckedSendable var embed = embed
-    return Self(embed: { [$embed] in $embed.wrappedValue($0) }, extract: extract)
+    #if swift(>=5.10)
+      nonisolated(unsafe) let embed = embed
+      return Self(embed: { embed($0) }, extract: extract)
+    #else
+      @UncheckedSendable var embed = embed
+      return Self(embed: { [$embed] in $embed.wrappedValue($0) }, extract: extract)
+    #endif
   }
 
   /// Returns a root by embedding a value.

--- a/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
+++ b/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
@@ -6,7 +6,7 @@ import XCTest
 final class CasePathableMacroTests: XCTestCase {
   override func invokeTest() {
     withMacroTesting(
-      //record: .failed,
+      // record: .failed,
       macros: [CasePathableMacro.self]
     ) {
       super.invokeTest()
@@ -1106,17 +1106,12 @@ final class CasePathableMacroTests: XCTestCase {
             return \.never
           }
           public var element: CasePaths.AnyCasePath<Action, _$Element> {
-            CasePaths.AnyCasePath<Action, _$Element>(
-              embed: {
-                Action.element($0)
-              },
-              extract: {
-                guard case let .element(v0) = $0 else {
-                  return nil
-                }
-                return v0
+            ._$embed(Action.element) {
+              guard case let .element(v0) = $0 else {
+                return nil
               }
-            )
+              return v0
+            }
           }
           public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Action>]> {
             var allCasePaths: [CasePaths.PartialCaseKeyPath<Action>] = []

--- a/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
+++ b/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
@@ -48,56 +48,38 @@ final class CasePathableMacroTests: XCTestCase {
             return \.never
           }
           public var bar: CasePaths.AnyCasePath<Foo, Void> {
-            CasePaths.AnyCasePath<Foo, Void>(
-              embed: {
+            ._$embed({
                 Foo.bar
-              },
-              extract: {
-                guard case .bar = $0 else {
-                  return nil
-                }
-                return ()
+              }) {
+              guard case .bar = $0 else {
+                return nil
               }
-            )
+              return ()
+            }
           }
           public var baz: CasePaths.AnyCasePath<Foo, Int> {
-            CasePaths.AnyCasePath<Foo, Int>(
-              embed: {
-                Foo.baz($0)
-              },
-              extract: {
-                guard case let .baz(v0) = $0 else {
-                  return nil
-                }
-                return v0
+            ._$embed(Foo.baz) {
+              guard case let .baz(v0) = $0 else {
+                return nil
               }
-            )
+              return v0
+            }
           }
           public var fizz: CasePaths.AnyCasePath<Foo, String> {
-            CasePaths.AnyCasePath<Foo, String>(
-              embed: {
-                Foo.fizz(buzz: $0)
-              },
-              extract: {
-                guard case let .fizz(v0) = $0 else {
-                  return nil
-                }
-                return v0
+            ._$embed(Foo.fizz) {
+              guard case let .fizz(v0) = $0 else {
+                return nil
               }
-            )
+              return v0
+            }
           }
           public var fizzier: CasePaths.AnyCasePath<Foo, (Int, buzzier: String)> {
-            CasePaths.AnyCasePath<Foo, (Int, buzzier: String)>(
-              embed: {
-                Foo.fizzier($0, buzzier: $1)
-              },
-              extract: {
-                guard case let .fizzier(v0, v1) = $0 else {
-                  return nil
-                }
-                return (v0, v1)
+            ._$embed(Foo.fizzier) {
+              guard case let .fizzier(v0, v1) = $0 else {
+                return nil
               }
-            )
+              return (v0, v1)
+            }
           }
           public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
             var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
@@ -136,7 +118,8 @@ final class CasePathableMacroTests: XCTestCase {
                   return allCasePaths.makeIterator()
               }
           }
-          public static var allCasePaths: AllCasePaths { AllCasePaths() }}
+          public static var allCasePaths: AllCasePaths { AllCasePaths() }
+      }
 
       extension EnumWithNoCases: CasePaths.CasePathable, CasePaths.CasePathIterable {
       }
@@ -164,16 +147,12 @@ final class CasePathableMacroTests: XCTestCase {
             return \.never
           }
           public var bar: CasePaths.AnyCasePath<Foo, Never> {
-            CasePaths.AnyCasePath<Foo, Never>(
-              embed: {  _ -> Foo in
-              },
-              extract: {
-                guard case let .bar(v0) = $0 else {
-                  return nil
-                }
-                return v0
+            ._$embed(Foo.bar) {
+              guard case let .bar(v0) = $0 else {
+                return nil
               }
-            )
+              return v0
+            }
           }
           public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
             var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
@@ -213,30 +192,20 @@ final class CasePathableMacroTests: XCTestCase {
             return \.never
           }
           public var bar: CasePaths.AnyCasePath<Foo, Int> {
-            CasePaths.AnyCasePath<Foo, Int>(
-              embed: {
-                Foo.bar($0)
-              },
-              extract: {
-                guard case let .bar(v0) = $0 else {
-                  return nil
-                }
-                return v0
+            ._$embed(Foo.bar) {
+              guard case let .bar(v0) = $0 else {
+                return nil
               }
-            )
+              return v0
+            }
           }
           public var baz: CasePaths.AnyCasePath<Foo, String> {
-            CasePaths.AnyCasePath<Foo, String>(
-              embed: {
-                Foo.baz($0)
-              },
-              extract: {
-                guard case let .baz(v0) = $0 else {
-                  return nil
-                }
-                return v0
+            ._$embed(Foo.baz) {
+              guard case let .baz(v0) = $0 else {
+                return nil
               }
-            )
+              return v0
+            }
           }
           public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
             var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
@@ -274,17 +243,12 @@ final class CasePathableMacroTests: XCTestCase {
             return \.never
           }
           public var bar: CasePaths.AnyCasePath<Foo, Int> {
-            CasePaths.AnyCasePath<Foo, Int>(
-              embed: {
-                Foo.bar($0)
-              },
-              extract: {
-                guard case let .bar(v0) = $0 else {
-                  return nil
-                }
-                return v0
+            ._$embed(Foo.bar) {
+              guard case let .bar(v0) = $0 else {
+                return nil
               }
-            )
+              return v0
+            }
           }
           public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
             var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
@@ -318,17 +282,12 @@ final class CasePathableMacroTests: XCTestCase {
             return \.never
           }
           public var bar: CasePaths.AnyCasePath<Foo, Int> {
-            CasePaths.AnyCasePath<Foo, Int>(
-              embed: {
-                Foo.bar($0)
-              },
-              extract: {
-                guard case let .bar(v0) = $0 else {
-                  return nil
-                }
-                return v0
+            ._$embed(Foo.bar) {
+              guard case let .bar(v0) = $0 else {
+                return nil
               }
-            )
+              return v0
+            }
           }
           public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
             var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
@@ -362,17 +321,12 @@ final class CasePathableMacroTests: XCTestCase {
             return \.never
           }
           public var bar: CasePaths.AnyCasePath<Foo, Int> {
-            CasePaths.AnyCasePath<Foo, Int>(
-              embed: {
-                Foo.bar($0)
-              },
-              extract: {
-                guard case let .bar(v0) = $0 else {
-                  return nil
-                }
-                return v0
+            ._$embed(Foo.bar) {
+              guard case let .bar(v0) = $0 else {
+                return nil
               }
-            )
+              return v0
+            }
           }
           public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
             var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
@@ -500,17 +454,12 @@ final class CasePathableMacroTests: XCTestCase {
             return \.never
           }
           public var bar: CasePaths.AnyCasePath<Foo, (Int, Bool)> {
-            CasePaths.AnyCasePath<Foo, (Int, Bool)>(
-              embed: {
-                Foo.bar(_: $0, _: $1)
-              },
-              extract: {
-                guard case let .bar(v0, v1) = $0 else {
-                  return nil
-                }
-                return (v0, v1)
+            ._$embed(Foo.bar) {
+              guard case let .bar(v0, v1) = $0 else {
+                return nil
               }
-            )
+              return (v0, v1)
+            }
           }
           public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
             var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
@@ -547,17 +496,12 @@ final class CasePathableMacroTests: XCTestCase {
             return \.never
           }
           public var bar: CasePaths.AnyCasePath<Foo, Bar<Foo>> {
-            CasePaths.AnyCasePath<Foo, Bar<Foo>>(
-              embed: {
-                Foo.bar($0)
-              },
-              extract: {
-                guard case let .bar(v0) = $0 else {
-                  return nil
-                }
-                return v0
+            ._$embed(Foo.bar) {
+              guard case let .bar(v0) = $0 else {
+                return nil
               }
-            )
+              return v0
+            }
           }
           public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
             var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
@@ -594,17 +538,12 @@ final class CasePathableMacroTests: XCTestCase {
             return \.never
           }
           public var bar: CasePaths.AnyCasePath<Foo, (int: Int, bool: Bool)> {
-            CasePaths.AnyCasePath<Foo, (int: Int, bool: Bool)>(
-              embed: {
-                Foo.bar(int: $0, bool: $1)
-              },
-              extract: {
-                guard case let .bar(v0, v1) = $0 else {
-                  return nil
-                }
-                return (v0, v1)
+            ._$embed(Foo.bar) {
+              guard case let .bar(v0, v1) = $0 else {
+                return nil
               }
-            )
+              return (v0, v1)
+            }
           }
           public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
             var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
@@ -704,114 +643,84 @@ final class CasePathableMacroTests: XCTestCase {
             return \.never
           }
           public var bar: CasePaths.AnyCasePath<Foo, Void> {
-            CasePaths.AnyCasePath<Foo, Void>(
-              embed: {
+            ._$embed({
                 Foo.bar
-              },
-              extract: {
-                guard case .bar = $0 else {
-                  return nil
-                }
-                return ()
+              }) {
+              guard case .bar = $0 else {
+                return nil
               }
-            )
+              return ()
+            }
           }
           #if os(macOS)
           public var macCase: CasePaths.AnyCasePath<Foo, Void> {
-            CasePaths.AnyCasePath<Foo, Void>(
-              embed: {
+            ._$embed({
                 Foo.macCase
-              },
-              extract: {
-                guard case .macCase = $0 else {
-                  return nil
-                }
-                return ()
+              }) {
+              guard case .macCase = $0 else {
+                return nil
               }
-            )
+              return ()
+            }
           }
           public var macSecond: CasePaths.AnyCasePath<Foo, Int> {
-            CasePaths.AnyCasePath<Foo, Int>(
-              embed: {
-                Foo.macSecond($0)
-              },
-              extract: {
-                guard case let .macSecond(v0) = $0 else {
-                  return nil
-                }
-                return v0
+            ._$embed(Foo.macSecond) {
+              guard case let .macSecond(v0) = $0 else {
+                return nil
               }
-            )
+              return v0
+            }
           }
           #elseif os(iOS)
           public var iosCase: CasePaths.AnyCasePath<Foo, Void> {
-            CasePaths.AnyCasePath<Foo, Void>(
-              embed: {
+            ._$embed({
                 Foo.iosCase
-              },
-              extract: {
-                guard case .iosCase = $0 else {
-                  return nil
-                }
-                return ()
+              }) {
+              guard case .iosCase = $0 else {
+                return nil
               }
-            )
+              return ()
+            }
           }
           #else
           public var elseCase: CasePaths.AnyCasePath<Foo, String> {
-            CasePaths.AnyCasePath<Foo, String>(
-              embed: {
-                Foo.elseCase($0)
-              },
-              extract: {
-                guard case let .elseCase(v0) = $0 else {
-                  return nil
-                }
-                return v0
+            ._$embed(Foo.elseCase) {
+              guard case let .elseCase(v0) = $0 else {
+                return nil
               }
-            )
+              return v0
+            }
           }
           public var elseLast: CasePaths.AnyCasePath<Foo, Void> {
-            CasePaths.AnyCasePath<Foo, Void>(
-              embed: {
+            ._$embed({
                 Foo.elseLast
-              },
-              extract: {
-                guard case .elseLast = $0 else {
-                  return nil
-                }
-                return ()
+              }) {
+              guard case .elseLast = $0 else {
+                return nil
               }
-            )
+              return ()
+            }
           }
           #endif
           #if DEBUG
           #if INNER
           public var twoLevelsDeep: CasePaths.AnyCasePath<Foo, Void> {
-            CasePaths.AnyCasePath<Foo, Void>(
-              embed: {
+            ._$embed({
                 Foo.twoLevelsDeep
-              },
-              extract: {
-                guard case .twoLevelsDeep = $0 else {
-                  return nil
-                }
-                return ()
+              }) {
+              guard case .twoLevelsDeep = $0 else {
+                return nil
               }
-            )
+              return ()
+            }
           }
           public var twoLevels: CasePaths.AnyCasePath<Foo, Double> {
-            CasePaths.AnyCasePath<Foo, Double>(
-              embed: {
-                Foo.twoLevels($0)
-              },
-              extract: {
-                guard case let .twoLevels(v0) = $0 else {
-                  return nil
-                }
-                return v0
+            ._$embed(Foo.twoLevels) {
+              guard case let .twoLevels(v0) = $0 else {
+                return nil
               }
-            )
+              return v0
+            }
           }
           #endif
           #endif
@@ -868,17 +777,14 @@ final class CasePathableMacroTests: XCTestCase {
             return \.never
           }
           public var bar: CasePaths.AnyCasePath<Foo, Void> {
-            CasePaths.AnyCasePath<Foo, Void>(
-              embed: {
+            ._$embed({
                 Foo.bar
-              },
-              extract: {
-                guard case .bar = $0 else {
-                  return nil
-                }
-                return ()
+              }) {
+              guard case .bar = $0 else {
+                return nil
               }
-            )
+              return ()
+            }
           }
           public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
             var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
@@ -954,33 +860,27 @@ final class CasePathableMacroTests: XCTestCase {
           }
           /// The bar case.
           public var bar: CasePaths.AnyCasePath<Foo, Void> {
-            CasePaths.AnyCasePath<Foo, Void>(
-              embed: {
+            ._$embed({
                 Foo.bar
-              },
-              extract: {
-                guard case .bar = $0 else {
-                  return nil
-                }
-                return ()
+              }) {
+              guard case .bar = $0 else {
+                return nil
               }
-            )
+              return ()
+            }
           }
           /// The baz case.
           ///
           /// A case for baz.
           public var baz: CasePaths.AnyCasePath<Foo, Void> {
-            CasePaths.AnyCasePath<Foo, Void>(
-              embed: {
+            ._$embed({
                 Foo.baz
-              },
-              extract: {
-                guard case .baz = $0 else {
-                  return nil
-                }
-                return ()
+              }) {
+              guard case .baz = $0 else {
+                return nil
               }
-            )
+              return ()
+            }
           }
           /**
          The fizz buzz case.
@@ -988,17 +888,14 @@ final class CasePathableMacroTests: XCTestCase {
          A case for fizz and buzz.
          */
           public var fizz: CasePaths.AnyCasePath<Foo, Void> {
-            CasePaths.AnyCasePath<Foo, Void>(
-              embed: {
+            ._$embed({
                 Foo.fizz
-              },
-              extract: {
-                guard case .fizz = $0 else {
-                  return nil
-                }
-                return ()
+              }) {
+              guard case .fizz = $0 else {
+                return nil
               }
-            )
+              return ()
+            }
           }
           /**
          The fizz buzz case.
@@ -1006,17 +903,14 @@ final class CasePathableMacroTests: XCTestCase {
          A case for fizz and buzz.
          */
           public var buzz: CasePaths.AnyCasePath<Foo, Void> {
-            CasePaths.AnyCasePath<Foo, Void>(
-              embed: {
+            ._$embed({
                 Foo.buzz
-              },
-              extract: {
-                guard case .buzz = $0 else {
-                  return nil
-                }
-                return ()
+              }) {
+              guard case .buzz = $0 else {
+                return nil
               }
-            )
+              return ()
+            }
           }
           public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
             var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
@@ -1063,17 +957,14 @@ final class CasePathableMacroTests: XCTestCase {
             // baz
           // case foo
           public var bar: CasePaths.AnyCasePath<Foo, Void> {
-            CasePaths.AnyCasePath<Foo, Void>(
-              embed: {
+            ._$embed({
                 Foo.bar
-              },
-              extract: {
-                guard case .bar = $0 else {
-                  return nil
-                }
-                return ()
+              }) {
+              guard case .bar = $0 else {
+                return nil
               }
-            )
+              return ()
+            }
           }
           public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
             var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
@@ -1133,69 +1024,48 @@ final class CasePathableMacroTests: XCTestCase {
           }
           // Comment above case
           public var bar: CasePaths.AnyCasePath<Foo, Void> {
-            CasePaths.AnyCasePath<Foo, Void>(
-              embed: {
+            ._$embed({
                 Foo.bar
-              },
-              extract: {
-                guard case .bar = $0 else {
-                  return nil
-                }
-                return ()
+              }) {
+              guard case .bar = $0 else {
+                return nil
               }
-            )
+              return ()
+            }
           }
           /*Comment before case*/public var baz: CasePaths.AnyCasePath<Foo, Int> {
-            CasePaths.AnyCasePath<Foo, Int>(
-              embed: {
-                Foo.baz($0)
-              },
-              extract: {
-                guard case let .baz(v0) = $0 else {
-                  return nil
-                }
-                return v0
+            ._$embed(Foo.baz) {
+              guard case let .baz(v0) = $0 else {
+                return nil
               }
-            )
+              return v0
+            }
           }
           public var fizz: CasePaths.AnyCasePath<Foo, String> {
-            CasePaths.AnyCasePath<Foo, String>(
-              embed: {
-                Foo.fizz(buzz: $0)
-              },
-              extract: {
-                guard case let .fizz(v0) = $0 else {
-                  return nil
-                }
-                return v0
+            ._$embed(Foo.fizz) {
+              guard case let .fizz(v0) = $0 else {
+                return nil
               }
-            )
+              return v0
+            }
           }
           public var fizzier: CasePaths.AnyCasePath<Foo, (Int, buzzier: String)> {
-            CasePaths.AnyCasePath<Foo, (Int, buzzier: String)>(
-              embed: {
-                Foo.fizzier($0, buzzier: $1)
-              },
-              extract: {
-                guard case let .fizzier(v0, v1) = $0 else {
-                  return nil
-                }
-                return (v0, v1)
+            ._$embed(Foo.fizzier) {
+              guard case let .fizzier(v0, v1) = $0 else {
+                return nil
               }
-            )
+              return (v0, v1)
+            }
           }
           public var fizziest: CasePaths.AnyCasePath<Foo, Void> {
-            CasePaths.AnyCasePath<Foo, Void>(
-              embed: {
+            ._$embed({
                 Foo.fizziest
-              },
-              extract: {
-                guard case .fizziest = $0 else {
-                  return nil
-                }
-                return ()
+              }) {
+              guard case .fizziest = $0 else {
+                return nil
               }
-            )
+              return ()
+            }
           }
           public func makeIterator() -> IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
             var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []

--- a/Tests/CasePathsTests/MacroTests.swift
+++ b/Tests/CasePathsTests/MacroTests.swift
@@ -12,5 +12,10 @@ private enum Comments {
 
 @CasePathable
 enum Action {
+  case alert(Alert)
+}
+
+@CasePathable
+enum Alert {
   case alert(Never)
 }


### PR DESCRIPTION
These closures are effectively sendable since they're "thin", but the initializer breaks the point-free style, and introduces unfortunate warnings when dealing with uninhabited enums.