### PR TITLE
Follow-up Wasm CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,21 +52,24 @@ jobs:
       OMIT_MACRO_TESTS: 1
     strategy:
       matrix:
-        toolchain:
-          - wasm-DEVELOPMENT-SNAPSHOT-2024-08-26-a
+        include:
+          - toolchain: swift-DEVELOPMENT-SNAPSHOT-2024-07-08-a
+            swift-sdk: swift-wasm-DEVELOPMENT-SNAPSHOT-2024-07-09-a
     steps:
-      - name: Cache toolchains
-        uses: actions/cache@v3
-        with:
-          path: ~/Library/Developer/Toolchains
-          key: ${{ matrix.toolchain }}
       - uses: actions/checkout@v4
       - uses: bytecodealliance/actions/wasmtime/setup@v1
-      - uses: swiftwasm/setup-swiftwasm@v1
-        with:
-          swift-version: ${{ matrix.toolchain }}
+      - name: Install Swift and Swift SDK for WebAssembly
+        run: |
+          PREFIX=/opt/swift
+          SWIFT_TOOLCHAIN_TAG="${{ matrix.toolchain }}"
+          SWIFT_SDK_TAG="${{ matrix.swift-sdk }}"
+          set -ex
+          curl -f -o /tmp/swift.tar.gz "https://download.swift.org/development/ubuntu2204/$SWIFT_TOOLCHAIN_TAG/$SWIFT_TOOLCHAIN_TAG-ubuntu22.04.tar.gz"
+          sudo mkdir -p $PREFIX; sudo tar -xzf /tmp/swift.tar.gz -C $PREFIX --strip-component 1
+          $PREFIX/usr/bin/swift experimental-sdk install "https://github.com/swiftwasm/swift/releases/download/$SWIFT_SDK_TAG/$SWIFT_SDK_TAG-wasm32-unknown-wasi.artifactbundle.zip"
+          echo "$PREFIX/usr/bin" >> $GITHUB_PATH
       - name: Build tests
-        run: swift build --static-swift-stdlib --triple wasm32-unknown-wasi --build-tests -Xlinker -z -Xlinker stack-size=$((1024 * 1024))
+        run: swift build --swift-sdk wasm32-unknown-wasi --build-tests -Xlinker -z -Xlinker stack-size=$((1024 * 1024))
       - name: Run tests
         run: wasmtime .build/debug/swift-case-pathsPackageTests.wasm
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Build tests
         run: swift build --swift-sdk wasm32-unknown-wasi --build-tests -Xlinker -z -Xlinker stack-size=$((1024 * 1024))
       - name: Run tests
-        run: wasmtime .build/debug/swift-case-pathsPackageTests.wasm
+        run: wasmtime --dir . .build/debug/swift-case-pathsPackageTests.wasm
 
   # windows:
   #   name: Windows (Swift ${{ matrix.swift }}, ${{ matrix.config }})

--- a/Tests/CasePathsTests/DeprecatedTests.swift
+++ b/Tests/CasePathsTests/DeprecatedTests.swift
@@ -144,20 +144,37 @@ final class DeprecatedTests: XCTestCase {
     XCTAssertNil(AnyCasePath(Enum.uninhabited).extract(from: .value))
   }
 
-  func testClosurePayload() throws {
-    enum Enum { case closure(() -> Void) }
-    let path = /Enum.closure
-    for _ in 1...2 {
+  // Dynamic closure payload extraction is not supported on WebAssembly
+  //
+  // Discussion:
+  // Closure payloads `() -> Void` are extracted via generic abstraction
+  // `Value` in `extractHelp`, and the extracted closure is called as
+  // `() -> @out τ_0_0 where τ_0_0 == Void`.
+  // However, the closure value is stored without generic abstraction
+  // in the enum payload storage, and not wrapped by abstraction thunk.
+  // This abstraction mismatch causes signature mismatch between the
+  // call-site and the actual callee. On most platforms, this mismatch
+  // is luckily not a problem, but WebAssembly enforces the signature
+  // match and causes a runtime crash.
+  // Ideally, `extractHelp` should insert an abstraction thunk when
+  // extracting a closure payload, but it cannot be done without
+  // JIT code generation (and WebAssembly does not support JIT...)
+  #if !arch(wasm32)
+    func testClosurePayload() throws {
+      enum Enum { case closure(() -> Void) }
+      let path = /Enum.closure
+      for _ in 1...2 {
+        var invoked = false
+        let closure = try unwrap(path.extract(from: .closure { invoked = true }))
+        closure()
+        XCTAssertTrue(invoked)
+      }
       var invoked = false
-      let closure = try unwrap(path.extract(from: .closure { invoked = true }))
+      let closure = try unwrap(AnyCasePath(Enum.closure).extract(from: .closure { invoked = true }))
       closure()
       XCTAssertTrue(invoked)
     }
-    var invoked = false
-    let closure = try unwrap(AnyCasePath(Enum.closure).extract(from: .closure { invoked = true }))
-    closure()
-    XCTAssertTrue(invoked)
-  }
+  #endif
 
   func testRecursivePayload() {
     indirect enum Enum: Equatable {
@@ -891,21 +908,25 @@ final class DeprecatedTests: XCTestCase {
     )
   }
 
-  func testEnumsWithClosures() {
-    enum Foo {
-      case bar(() -> Void)
-    }
+  // Dynamic closure payload extraction is not supported on WebAssembly
+  // See testClosurePayload for more details
+  #if !arch(wasm32)
+    func testEnumsWithClosures() {
+      enum Foo {
+        case bar(() -> Void)
+      }
 
-    var didRun = false
-    let fooBar = /Foo.bar
-    guard let bar = fooBar.extract(from: .bar { didRun = true })
-    else {
-      XCTFail()
-      return
+      var didRun = false
+      let fooBar = /Foo.bar
+      guard let bar = fooBar.extract(from: .bar { didRun = true })
+      else {
+        XCTFail()
+        return
+      }
+      bar()
+      XCTAssertTrue(didRun)
     }
-    bar()
-    XCTAssertTrue(didRun)
-  }
+  #endif
 
   func testRecursive() {
     indirect enum Foo {
@@ -1202,10 +1223,12 @@ final class DeprecatedTests: XCTestCase {
     )
   }
 
-  #if os(Windows)
+  #if os(Windows) || arch(wasm32)
     // There seems to be some strangeness with the current
     // concurrency implmentation on Windows that breaks if
     // you have more than 100 tasks here.
+    // WebAssembly doesn't support tail-call for now, so we
+    // have smaller limit as well.
     let maxIterations = 100
   #else
     let maxIterations = 100_000


### PR DESCRIPTION
We are moving to Swift SDK-style installation on the development branch, and `swift test` with static stdlib is broken in obsoleting toolchain-style installation now.

Verified it works here ✅  https://github.com/kateinoigakukun/swift-case-paths/actions/runs/10591664518/job/29349506477