### PR TITLE
[Proposal] Add Swift Macro Compatibility Check GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,18 @@ jobs:
       - name: Run tests
         run: wasmtime --dir . .build/debug/swift-case-pathsPackageTests.wasm
 
+  check-macro-compatibility:
+    name: Check Macro Compatibility
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run Swift Macro Compatibility Check
+        uses: Matejkob/swift-macro-compatibility-check@v1.0.0
+        with:
+          run-tests: false
+          major-versions-only: false
+
   # windows:
   #   name: Windows (Swift ${{ matrix.swift }}, ${{ matrix.config }})
   #   strategy:


### PR DESCRIPTION
This PR adds a **Swift Macro Compatibility Check** GitHub Action to ensure that macro changes remain compatible across different versions of `swift-syntax`. The action automatically verifies compatibility with major `swift-syntax` versions (`509.0.0`, `510.0.0`, `600.0.0`), running builds and tests. It's also posible to turn on checking agains all versions of `swift-syntax`.

#### Key Benefits:
- **Automated Compatibility Checks**: No need to manually test changes across different `swift-syntax` versions—this is handled automatically in CI.
- **Prevents Breakages**: Helps avoid accidentally committing changes that break older versions.