### PR TITLE
Update dependencies, to avoid build issues with Xcode 16 on `make test-swift`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         xcode:
           - '15.4'
+          - '16.0'
     steps:
       - uses: actions/checkout@v4
       - name: Select Xcode ${{ matrix.xcode }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Xcode Select
-        run: sudo xcode-select -s /Applications/Xcode_15.0.app
+        run: sudo xcode-select -s /Applications/Xcode_16.0.app
       - name: Tap
         run: brew install swift-format
       - name: Format

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "d955dccabe54030895917a92ad252b0a5d4e823f6fefc262cdb2869f8731dbe4",
   "pins" : [
     {
       "identity" : "swift-docc-plugin",
@@ -23,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-macro-testing",
       "state" : {
-        "revision" : "a35257b7e9ce44e92636447003a8eeefb77b145c",
-        "version" : "0.5.1"
+        "revision" : "20c1a8f3b624fb5d1503eadcaa84743050c350f4",
+        "version" : "0.5.2"
       }
     },
     {
@@ -32,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "c097f955b4e724690f0fc8ffb7a6d4b881c9c4e3",
-        "version" : "1.17.2"
+        "revision" : "7b0bbbae90c41f848f90ac7b4df6c4f50068256d",
+        "version" : "1.17.5"
       }
     },
     {
@@ -55,5 +56,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }


### PR DESCRIPTION
Previously, running `make test-swift` would result in build errors with Xcode 16 selected, i.e. 

![image](https://github.com/user-attachments/assets/423bd085-fdc7-4518-85ec-fb9a15409767)

Updated several dependencies to resolve this, and have the command complete successfully. 

Additionally, updated CI to ensure Xcode 16 is being used across actions. 