### PR TITLE
Create a Makefile target simulating building for Library Evolution; address issues with Xcode 16 running it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   macos:
     name: macOS (Xcode ${{ matrix.xcode }})
-    runs-on: macos-latest
+    runs-on: macos-14
     strategy:
       matrix:
         xcode:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   macos:
     name: macOS (Xcode ${{ matrix.xcode }})
-    runs-on: macos-14
+    runs-on: macos-latest
     strategy:
       matrix:
         xcode:
@@ -30,6 +30,23 @@ jobs:
         run: swift --version
       - name: Run tests
         run: make test-swift
+
+  macos-library-evolution:
+    name: macOS Library Evolution (Xcode ${{ matrix.xcode }})
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        xcode:
+          - '15.4'
+          - '16.0'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Xcode ${{ matrix.xcode }}
+        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+      - name: Print Swift version
+        run: swift --version
+      - name: Build for Library Evolution
+        run: make build-for-library-evolution
 
   linux:
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ build-for-library-evolution:
 		--target CasePaths \
 		-Xswiftc -emit-module-interface \
 		-Xswiftc -enable-library-evolution
+		-Xswiftc -DRESILIENT_LIBRARIES \ # Required to build swift-syntax; see https://github.com/swiftlang/swift-syntax/pull/2540
 
 format:
 	swift format --in-place --recursive .

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,13 @@ test-swift:
 		-c release \
 		--parallel
 
+build-for-library-evolution:
+	swift build \
+		-c release \
+		--target CasePaths \
+		-Xswiftc -emit-module-interface \
+		-Xswiftc -enable-library-evolution
+
 format:
 	swift format --in-place --recursive .
 

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ build-for-library-evolution:
 		-c release \
 		--target CasePaths \
 		-Xswiftc -emit-module-interface \
-		-Xswiftc -enable-library-evolution
-		-Xswiftc -DRESILIENT_LIBRARIES \ # Required to build swift-syntax; see https://github.com/swiftlang/swift-syntax/pull/2540
+		-Xswiftc -enable-library-evolution \
+		-Xswiftc -DRESILIENT_LIBRARIES # Required to build swift-syntax; see https://github.com/swiftlang/swift-syntax/pull/2540
 
 format:
 	swift format --in-place --recursive .

--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "4c6cc0a3b9e8f14b3ae2307c5ccae4de6167ac2c",
-        "version" : "600.0.0-prerelease-2024-06-12"
+        "revision" : "cb53fa1bd3219b0b23ded7dfdd3b2baff266fd25",
+        "version" : "600.0.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "357ca1e5dd31f613a1d43320870ebc219386a495",
-        "version" : "1.2.2"
+        "revision" : "27d767d643fa2cf083d0a73d74fa84cacb53e85c",
+        "version" : "1.4.1"
       }
     }
   ],

--- a/Sources/CasePathsMacros/CasePathableMacro.swift
+++ b/Sources/CasePathsMacros/CasePathableMacro.swift
@@ -292,6 +292,7 @@ extension AttributeListSyntax.Element {
       if let availability = ifConfig.availability {
         return .ifConfigDecl(availability)
       }
+    @unknown default: return nil
     }
     return nil
   }


### PR DESCRIPTION
- Add `build-for-library-evolution` target to the Makefile. This replicates an issue I'm seeing in our project building with Xcode 16, i.e. - 

![image](https://github.com/user-attachments/assets/04e00c6f-8441-462a-a4b4-89c437f998e7)
 
- Updates some dependencies to address various errors outside of this repository affecting the `build-for-library-evolution` target
- Adds `@unknown default` to one switch statement inside this project causing some issues

Happy to add CI around this target if desired; let me know what you think! 