### PR TITLE
Fix SwiftWasm CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         include:
           - toolchain: swift-DEVELOPMENT-SNAPSHOT-2024-09-18-a
             swift-sdk: swift-wasm-DEVELOPMENT-SNAPSHOT-2024-09-20-a
-            swift-sdk-checksum: 30c5b7a67c1274c53b618a26da3a977c
+            swift-sdk-checksum: ac7318b8beee4870162292715654499127833b847af6b3d94c32e574579ea189
     steps:
       - uses: actions/checkout@v4
       - uses: bytecodealliance/actions/wasmtime/setup@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         include:
           - toolchain: swift-DEVELOPMENT-SNAPSHOT-2024-09-18-a
             swift-sdk: swift-wasm-DEVELOPMENT-SNAPSHOT-2024-09-20-a
-            swift-sdk-checksum: ac7318b8beee4870162292715654499127833b847af6b3d94c32e574579ea189
+            checksum: ac7318b8beee4870162292715654499127833b847af6b3d94c32e574579ea189
     steps:
       - uses: actions/checkout@v4
       - uses: bytecodealliance/actions/wasmtime/setup@v1
@@ -82,11 +82,10 @@ jobs:
           PREFIX=/opt/swift
           SWIFT_TOOLCHAIN_TAG="${{ matrix.toolchain }}"
           SWIFT_SDK_TAG="${{ matrix.swift-sdk }}"
-          SWIFT_SDK_CHECKSUM="${{ matrix.swift-sdk-checksum }}"
           set -ex
           curl -f -o /tmp/swift.tar.gz "https://download.swift.org/development/ubuntu2204/$SWIFT_TOOLCHAIN_TAG/$SWIFT_TOOLCHAIN_TAG-ubuntu22.04.tar.gz"
           sudo mkdir -p $PREFIX; sudo tar -xzf /tmp/swift.tar.gz -C $PREFIX --strip-component 1
-          $PREFIX/usr/bin/swift sdk install "https://github.com/swiftwasm/swift/releases/download/$SWIFT_SDK_TAG/$SWIFT_SDK_TAG-wasm32-unknown-wasi.artifactbundle.zip" --checksum $SWIFT_SDK_CHECKSUM
+          $PREFIX/usr/bin/swift sdk install "https://github.com/swiftwasm/swift/releases/download/$SWIFT_SDK_TAG/$SWIFT_SDK_TAG-wasm32-unknown-wasi.artifactbundle.zip" --checksum ${{ matrix.checksum }}
           echo "$PREFIX/usr/bin" >> $GITHUB_PATH
       - name: Build tests
         run: swift build --swift-sdk wasm32-unknown-wasi --build-tests -Xlinker -z -Xlinker stack-size=$((1024 * 1024))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - toolchain: swift-DEVELOPMENT-SNAPSHOT-2024-07-08-a
-            swift-sdk: swift-wasm-DEVELOPMENT-SNAPSHOT-2024-07-09-a
+          - toolchain: swift-DEVELOPMENT-SNAPSHOT-2024-09-18-a
+            swift-sdk: swift-wasm-DEVELOPMENT-SNAPSHOT-2024-09-20-a
     steps:
       - uses: actions/checkout@v4
       - uses: bytecodealliance/actions/wasmtime/setup@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
         include:
           - toolchain: swift-DEVELOPMENT-SNAPSHOT-2024-09-18-a
             swift-sdk: swift-wasm-DEVELOPMENT-SNAPSHOT-2024-09-20-a
+            swift-sdk-checksum: 30c5b7a67c1274c53b618a26da3a977c
     steps:
       - uses: actions/checkout@v4
       - uses: bytecodealliance/actions/wasmtime/setup@v1
@@ -81,10 +82,11 @@ jobs:
           PREFIX=/opt/swift
           SWIFT_TOOLCHAIN_TAG="${{ matrix.toolchain }}"
           SWIFT_SDK_TAG="${{ matrix.swift-sdk }}"
+          SWIFT_SDK_CHECKSUM="${{ matrix.swift-sdk-checksum }}"
           set -ex
           curl -f -o /tmp/swift.tar.gz "https://download.swift.org/development/ubuntu2204/$SWIFT_TOOLCHAIN_TAG/$SWIFT_TOOLCHAIN_TAG-ubuntu22.04.tar.gz"
           sudo mkdir -p $PREFIX; sudo tar -xzf /tmp/swift.tar.gz -C $PREFIX --strip-component 1
-          $PREFIX/usr/bin/swift experimental-sdk install "https://github.com/swiftwasm/swift/releases/download/$SWIFT_SDK_TAG/$SWIFT_SDK_TAG-wasm32-unknown-wasi.artifactbundle.zip"
+          $PREFIX/usr/bin/swift sdk install "https://github.com/swiftwasm/swift/releases/download/$SWIFT_SDK_TAG/$SWIFT_SDK_TAG-wasm32-unknown-wasi.artifactbundle.zip" --checksum $SWIFT_SDK_CHECKSUM
           echo "$PREFIX/usr/bin" >> $GITHUB_PATH
       - name: Build tests
         run: swift build --swift-sdk wasm32-unknown-wasi --build-tests -Xlinker -z -Xlinker stack-size=$((1024 * 1024))


### PR DESCRIPTION
The old snapshots did not support the renamed `swiftLanguageModes` Package.swift parameter.