### PR TITLE
Added a convenience `is` function for optional CasePathable values

### DIFF
--- a/Sources/CasePaths/Optional+CasePathable.swift
+++ b/Sources/CasePaths/Optional+CasePathable.swift
@@ -88,23 +88,8 @@ extension Optional.AllCasePaths: Sequence {
 }
 
 extension Optional where Wrapped: CasePathable {
-  /// Tests the associated value of an optional case.
-  ///
-  /// ```swift
-  /// @CasePathable
-  /// enum UserAction {
-  ///   case home(HomeAction)
-  ///   case settings(SettingsAction)
-  /// }
-  ///
-  /// let userAction: UserAction? = .home(.onAppear)
-  /// userAction.is(\.home)      // true
-  /// userAction.is(\.settings)  // false
-  ///
-  /// let userActions: [UserAction] = [.home(.onAppear), .settings(.subscribeButtonTapped)]
-  /// userActions.filter { $0.is(\.home) }      // [UserAction.home(.onAppear)]
-  /// userActions.filter { $0.is(\.settings) }  // [UserAction.settings(.subscribeButtonTapped)]
-  /// ```
+  @_disfavoredOverload
+  @_documentation(visibility:internal)
   public func `is`(_ keyPath: PartialCaseKeyPath<Wrapped>) -> Bool {
     self?[case: keyPath] != nil
   }

--- a/Sources/CasePaths/Optional+CasePathable.swift
+++ b/Sources/CasePaths/Optional+CasePathable.swift
@@ -88,6 +88,23 @@ extension Optional.AllCasePaths: Sequence {
 }
 
 extension Optional where Wrapped: CasePathable {
+  /// Tests the associated value of an optional case.
+  ///
+  /// ```swift
+  /// @CasePathable
+  /// enum UserAction {
+  ///   case home(HomeAction)
+  ///   case settings(SettingsAction)
+  /// }
+  ///
+  /// let userAction: UserAction? = .home(.onAppear)
+  /// userAction.is(\.home)      // true
+  /// userAction.is(\.settings)  // false
+  ///
+  /// let userActions: [UserAction] = [.home(.onAppear), .settings(.subscribeButtonTapped)]
+  /// userActions.filter { $0.is(\.home) }      // [UserAction.home(.onAppear)]
+  /// userActions.filter { $0.is(\.settings) }  // [UserAction.settings(.subscribeButtonTapped)]
+  /// ```
   public func `is`(_ keyPath: PartialCaseKeyPath<Wrapped>) -> Bool {
     self?[case: keyPath] != nil
   }

--- a/Sources/CasePaths/Optional+CasePathable.swift
+++ b/Sources/CasePaths/Optional+CasePathable.swift
@@ -86,3 +86,9 @@ extension Optional.AllCasePaths: Sequence {
     [\.none, \.some].makeIterator()
   }
 }
+
+extension Optional where Wrapped: CasePathable {
+  public func `is`(_ keyPath: PartialCaseKeyPath<Wrapped>) -> Bool {
+    self?[case: keyPath] != nil
+  }
+}


### PR DESCRIPTION
This PR is aimed at improving ergonomics for `is` checks specifically in TCA. Destinations and other pieces of CasePathable state can often be optional in TCA, and so out of the box the `CasePathable.is` function requires either unwrapping the optional state or tacking on `== true` to compile. I defined this extension in my own codebase a while ago to make that syntax a bit nicer to read, so as I was copying it over to another project I thought it might be worth submitting for inclusion right in the library itself