### PR TITLE
Update Macro Compatibility Check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,10 +99,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Run Swift Macro Compatibility Check
-        uses: Matejkob/swift-macro-compatibility-check@v1.0.0
+        uses: Matejkob/swift-macro-compatibility-check@v1
         with:
           run-tests: false
-          major-versions-only: false
+          major-versions-only: true
 
   # windows:
   #   name: Windows (Swift ${{ matrix.swift }}, ${{ matrix.config }})


### PR DESCRIPTION
* Use `v1` version instead of `v1.0.0` 
* Use major versions only instead of checking against all versions. 