### PR TITLE
Clean up dynamic member lookup key path sendability

### DIFF
--- a/Sources/CasePaths/CasePathable.swift
+++ b/Sources/CasePaths/CasePathable.swift
@@ -69,33 +69,20 @@ extension Case {
     self = Case<Root>()[keyPath: keyPath]
   }
 
-  // #if swift(>=6)
-  //   public subscript<AppendedValue>(
-  //     dynamicMember keyPath: KeyPath<Value.AllCasePaths, AnyCasePath<Value, AppendedValue>>
-  //       & Sendable
-  //   ) -> Case<AppendedValue>
-  //   where Value: CasePathable {
-  //     Case<AppendedValue>(
-  //       embed: { embed(Value.allCasePaths[keyPath: keyPath].embed($0)) },
-  //       extract: { extract(from: $0).flatMap(Value.allCasePaths[keyPath: keyPath].extract) }
-  //     )
-  //   }
-  // #else
   public subscript<AppendedValue>(
     dynamicMember keyPath: KeyPath<Value.AllCasePaths, AnyCasePath<Value, AppendedValue>>
   ) -> Case<AppendedValue>
   where Value: CasePathable {
-    @UncheckedSendable var keyPath = keyPath
+    let keyPath = keyPath.unsafeSendable()
     return Case<AppendedValue>(
-      embed: { [$keyPath] in
-        embed(Value.allCasePaths[keyPath: $keyPath.wrappedValue].embed($0))
+      embed: {
+        embed(Value.allCasePaths[keyPath: keyPath].embed($0))
       },
-      extract: { [$keyPath] in
-        extract(from: $0).flatMap(Value.allCasePaths[keyPath: $keyPath.wrappedValue].extract)
+      extract: {
+        extract(from: $0).flatMap(Value.allCasePaths[keyPath: keyPath].extract)
       }
     )
   }
-  // #endif
 
   public func embed(_ value: Value) -> Any {
     self._embed(value)
@@ -521,25 +508,6 @@ extension AnyCasePath {
 }
 
 extension AnyCasePath where Value: CasePathable {
-  // #if swift(>=6)
-  //   /// Returns a new case path created by appending the case path at the given key path to this one.
-  //   ///
-  //   /// This subscript is automatically invoked by case key path expressions via dynamic member
-  //   /// lookup, and should not be invoked directly.
-  //   ///
-  //   /// - Parameter keyPath: A key path to a case-pathable case path.
-  //   public subscript<AppendedValue>(
-  //     dynamicMember keyPath: KeyPath<Value.AllCasePaths, AnyCasePath<Value, AppendedValue>>
-  //       & Sendable
-  //   ) -> AnyCasePath<Root, AppendedValue> {
-  //     AnyCasePath<Root, AppendedValue>(
-  //       embed: { self.embed(Value.allCasePaths[keyPath: keyPath].embed($0)) },
-  //       extract: {
-  //         self.extract(from: $0).flatMap(Value.allCasePaths[keyPath: keyPath].extract(from:))
-  //       }
-  //     )
-  //   }
-  // #else
   /// Returns a new case path created by appending the case path at the given key path to this one.
   ///
   /// This subscript is automatically invoked by case key path expressions via dynamic member
@@ -549,17 +517,16 @@ extension AnyCasePath where Value: CasePathable {
   public subscript<AppendedValue>(
     dynamicMember keyPath: KeyPath<Value.AllCasePaths, AnyCasePath<Value, AppendedValue>>
   ) -> AnyCasePath<Root, AppendedValue> {
-    @UncheckedSendable var keyPath = keyPath
+    let keyPath = keyPath.unsafeSendable()
     return AnyCasePath<Root, AppendedValue>(
-      embed: { [$keyPath] in
-        embed(Value.allCasePaths[keyPath: $keyPath.wrappedValue].embed($0))
+      embed: {
+        embed(Value.allCasePaths[keyPath: keyPath].embed($0))
       },
-      extract: { [$keyPath] in
+      extract: {
         extract(from: $0).flatMap(
-          Value.allCasePaths[keyPath: $keyPath.wrappedValue].extract(from:)
+          Value.allCasePaths[keyPath: keyPath].extract(from:)
         )
       }
     )
   }
-  // #endif
 }

--- a/Sources/CasePaths/Internal/KeyPath+Sendable.swift
+++ b/Sources/CasePaths/Internal/KeyPath+Sendable.swift
@@ -1,9 +1,3 @@
-#if compiler(>=6)
-  public typealias _SendableKeyPath<Root, Value> = any KeyPath<Root, Value> & Sendable
-#else
-  public typealias _SendableKeyPath<Root, Value> = KeyPath<Root, Value>
-#endif
-
 // NB: Dynamic member lookup does not currently support sendable key paths and even breaks
 //     autocomplete.
 //

--- a/Sources/CasePaths/Internal/KeyPath+Sendable.swift
+++ b/Sources/CasePaths/Internal/KeyPath+Sendable.swift
@@ -1,10 +1,7 @@
 #if compiler(>=6)
   public typealias _SendableKeyPath<Root, Value> = any KeyPath<Root, Value> & Sendable
-  public typealias _SendableWritableKeyPath<Root, Value> = any WritableKeyPath<Root, Value>
-    & Sendable
 #else
   public typealias _SendableKeyPath<Root, Value> = KeyPath<Root, Value>
-  public typealias _SendableWritableKeyPath<Root, Value> = WritableKeyPath<Root, Value>
 #endif
 
 // NB: Dynamic member lookup does not currently support sendable key paths and even breaks
@@ -18,16 +15,6 @@ extension _AppendKeyPath {
   where Self == KeyPath<Root, Value> {
     #if compiler(>=6)
       unsafeBitCast(self, to: _SendableKeyPath<Root, Value>.self)
-    #else
-      self
-    #endif
-  }
-
-  @_transparent
-  package func unsafeSendable<Root, Value>() -> _SendableWritableKeyPath<Root, Value>
-  where Self == WritableKeyPath<Root, Value> {
-    #if compiler(>=6)
-      unsafeBitCast(self, to: _SendableWritableKeyPath<Root, Value>.self)
     #else
       self
     #endif

--- a/Sources/CasePaths/Internal/KeyPath+Sendable.swift
+++ b/Sources/CasePaths/Internal/KeyPath+Sendable.swift
@@ -1,0 +1,35 @@
+#if compiler(>=6)
+  public typealias _SendableKeyPath<Root, Value> = any KeyPath<Root, Value> & Sendable
+  public typealias _SendableWritableKeyPath<Root, Value> = any WritableKeyPath<Root, Value>
+    & Sendable
+#else
+  public typealias _SendableKeyPath<Root, Value> = KeyPath<Root, Value>
+  public typealias _SendableWritableKeyPath<Root, Value> = WritableKeyPath<Root, Value>
+#endif
+
+// NB: Dynamic member lookup does not currently support sendable key paths and even breaks
+//     autocomplete.
+//
+//     * https://github.com/swiftlang/swift/issues/77035
+//     * https://github.com/swiftlang/swift/issues/77105
+extension _AppendKeyPath {
+  @_transparent
+  package func unsafeSendable<Root, Value>() -> _SendableKeyPath<Root, Value>
+  where Self == KeyPath<Root, Value> {
+    #if compiler(>=6)
+      unsafeBitCast(self, to: _SendableKeyPath<Root, Value>.self)
+    #else
+      self
+    #endif
+  }
+
+  @_transparent
+  package func unsafeSendable<Root, Value>() -> _SendableWritableKeyPath<Root, Value>
+  where Self == WritableKeyPath<Root, Value> {
+    #if compiler(>=6)
+      unsafeBitCast(self, to: _SendableWritableKeyPath<Root, Value>.self)
+    #else
+      self
+    #endif
+  }
+}

--- a/Sources/CasePaths/Internal/KeyPath+Sendable.swift
+++ b/Sources/CasePaths/Internal/KeyPath+Sendable.swift
@@ -5,10 +5,10 @@
 //     * https://github.com/swiftlang/swift/issues/77105
 extension _AppendKeyPath {
   @_transparent
-  package func unsafeSendable<Root, Value>() -> _SendableKeyPath<Root, Value>
+  package func unsafeSendable<Root, Value>() -> any Sendable & KeyPath<Root, Value>
   where Self == KeyPath<Root, Value> {
     #if compiler(>=6)
-      unsafeBitCast(self, to: _SendableKeyPath<Root, Value>.self)
+      unsafeBitCast(self, to: (any Sendable & KeyPath<Root, Value>).self)
     #else
       self
     #endif

--- a/Sources/CasePaths/Internal/KeyPath+Sendable.swift
+++ b/Sources/CasePaths/Internal/KeyPath+Sendable.swift
@@ -1,3 +1,9 @@
+#if compiler(>=6)
+  public typealias _SendableKeyPath<Root, Value> = any Sendable & KeyPath<Root, Value>
+#else
+  public typealias _SendableKeyPath<Root, Value> = KeyPath<Root, Value>
+#endif
+
 // NB: Dynamic member lookup does not currently support sendable key paths and even breaks
 //     autocomplete.
 //
@@ -5,10 +11,10 @@
 //     * https://github.com/swiftlang/swift/issues/77105
 extension _AppendKeyPath {
   @_transparent
-  package func unsafeSendable<Root, Value>() -> any Sendable & KeyPath<Root, Value>
+  package func unsafeSendable<Root, Value>() -> _SendableKeyPath<Root, Value>
   where Self == KeyPath<Root, Value> {
     #if compiler(>=6)
-      unsafeBitCast(self, to: (any Sendable & KeyPath<Root, Value>).self)
+      unsafeBitCast(self, to: _SendableKeyPath<Root, Value>.self)
     #else
       self
     #endif

--- a/Sources/CasePaths/Optional+CasePathable.swift
+++ b/Sources/CasePaths/Optional+CasePathable.swift
@@ -54,19 +54,6 @@ extension Optional: CasePathable, CasePathIterable {
 }
 
 extension Case {
-  // #if swift(>=6)
-  //   /// A case path to the presence of a nested value.
-  //   ///
-  //   /// This subscript can chain into an optional's wrapped value without explicitly specifying each
-  //   /// `some` component.
-  //   @_disfavoredOverload
-  //   public subscript<Member>(
-  //     dynamicMember keyPath: KeyPath<Value.AllCasePaths, AnyCasePath<Value, Member?>> & Sendable
-  //   ) -> Case<Member>
-  //   where Value: CasePathable {
-  //     self[dynamicMember: keyPath].some
-  //   }
-  // #else
   /// A case path to the presence of a nested value.
   ///
   /// This subscript can chain into an optional's wrapped value without explicitly specifying each
@@ -78,7 +65,6 @@ extension Case {
   where Value: CasePathable {
     self[dynamicMember: keyPath].some
   }
-  // #endif
 }
 
 extension Optional.AllCasePaths: Sequence {

--- a/Tests/CasePathsTests/CaseSetTests.swift
+++ b/Tests/CasePathsTests/CaseSetTests.swift
@@ -16,14 +16,14 @@
     }
 
     public subscript<Member>(
-      dynamicMember keyPath: CaseKeyPath<Element, Member> & Sendable
+      dynamicMember keyPath: CaseKeyPath<Element, Member> // & Sendable
     ) -> Member? {
       get { storage[keyPath].flatMap { $0[case: keyPath] } }
       set { storage[keyPath] = newValue.map(keyPath.callAsFunction) }
     }
 
     public subscript(
-      dynamicMember keyPath: CaseKeyPath<Element, Void> & Sendable
+      dynamicMember keyPath: CaseKeyPath<Element, Void> // & Sendable
     ) -> Bool {
       get { storage[keyPath].flatMap { $0[case: keyPath] } != nil }
       set { storage[keyPath] = newValue ? keyPath() : nil }
@@ -153,9 +153,9 @@
   extension CaseSet {
     @_disfavoredOverload
     public subscript<Member>(
-      dynamicMember keyPath: CaseKeyPath<Element, Member> & Sendable
+      dynamicMember keyPath: CaseKeyPath<Element, Member> // & Sendable
     ) -> CaseSetBuilder<Element, Member> {
-      CaseSetBuilder(set: self, keyPath: keyPath)
+      CaseSetBuilder(set: self, keyPath: keyPath.unsafeSendable())
     }
   }
 


### PR DESCRIPTION
Dynamic member lookup does not currently support sendable key paths, and we've had commented-out code as a result, but let's clean it up in favor of solutions employed in our other repos.