### PR TITLE
Add CasePathsCore usage example

### DIFF
--- a/Sources/CasePathsCore/Documentation.docc/CasePathsCore.md
+++ b/Sources/CasePathsCore/Documentation.docc/CasePathsCore.md
@@ -10,6 +10,40 @@ macro, and is automatically imported when you `import CasePaths`
 See the [`CasePaths`](../casepaths) module for information about the `@CasePathable` macro and
 other non-core functionality.
 
+To use Case paths without relying on the `@CasePathable` macro import `CasePathsCore` and manually conform your type to the `CasePathable` protocol.
+
+For example the `Result` type is extended to be case-pathable with the following extension:
+
+```swift
+import CasePathsCore
+
+extension Result: CasePathable {
+  public struct AllCasePaths {
+    var success: AnyCasePath<Result, Success> {
+      AnyCasePath(
+        embed: { .success($0) },
+        extract: {
+          guard case let .success(value) = $0 else { return nil }
+          return value
+        }
+      )
+    }
+
+    var failure: AnyCasePath<Result, Failure> {
+      AnyCasePath(
+        embed: { .failure($0) },
+        extract: {
+          guard case let .failure(value) = $0 else { return nil }
+          return value
+        }
+      )
+    }
+  }
+
+  public static var allCasePaths: AllCasePaths { AllCasePaths() }
+}
+```
+
 ## Topics
 
 ### Creating case paths


### PR DESCRIPTION
I was looking for an explanation on how to use  `CasePathsCore` and happened to found it in the `CasePathable` documentation comment. 

Before I found it though I wasn't aware that `CasePathable` was the protocol the macro synthesized conformance for. This moves the information to a place that is easier to find. Although maybe it should even be in a CasePathsCore README?