### PR TITLE
Add support for Swift 6.1 trailing commas

### DIFF
--- a/Sources/CasePathsMacros/CasePathableMacro.swift
+++ b/Sources/CasePathsMacros/CasePathableMacro.swift
@@ -435,6 +435,13 @@ extension EnumCaseElementListSyntax.Element {
             associatedValue.parameters[index].secondName = nil
           }
         }
+        
+        // Remove trailing comma from the last parameter for tuple type generation
+        if let lastIndex = associatedValue.parameters.indices.last {
+          associatedValue.parameters[lastIndex] = associatedValue.parameters[lastIndex]
+            .with(\.trailingComma, nil)
+        }
+        
         return "(\(associatedValue.parameters.trimmed))"
       }
     } else {


### PR DESCRIPTION
Turns out the [issue](https://github.com/pointfreeco/swift-composable-architecture/issues/3709) was actually coming from swift-case-paths.

I would've added tests, but the MacroTests don't seem to be building. Not sure if that's a me problem, or a know problem.