### PR TITLE
Update package versioning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 
 import CompilerPluginSupport
 import Foundation
@@ -52,7 +52,8 @@ let package = Package(
       name: "CasePathsTests",
       dependencies: ["CasePaths"]
     ),
-  ]
+  ],
+  swiftLanguageModes: [.v6]
 )
 
 #if !os(Windows)
@@ -78,16 +79,4 @@ if ProcessInfo.processInfo.environment["OMIT_MACRO_TESTS"] == nil {
       ]
     )
   )
-}
-
-for target in package.targets {
-  target.swiftSettings = target.swiftSettings ?? []
-  target.swiftSettings?.append(contentsOf: [
-    .enableExperimentalFeature("StrictConcurrency")
-  ])
-  // target.swiftSettings?.append(
-  //   .unsafeFlags([
-  //     "-enable-library-evolution",
-  //   ])
-  // )
 }

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 5.9
 
 import CompilerPluginSupport
 import Foundation
@@ -52,8 +52,7 @@ let package = Package(
       name: "CasePathsTests",
       dependencies: ["CasePaths"]
     ),
-  ],
-  swiftLanguageModes: [.v6]
+  ]
 )
 
 #if !os(Windows)
@@ -79,4 +78,16 @@ if ProcessInfo.processInfo.environment["OMIT_MACRO_TESTS"] == nil {
       ]
     )
   )
+}
+
+for target in package.targets {
+  target.swiftSettings = target.swiftSettings ?? []
+  target.swiftSettings?.append(contentsOf: [
+    .enableExperimentalFeature("StrictConcurrency")
+  ])
+  // target.swiftSettings?.append(
+  //   .unsafeFlags([
+  //     "-enable-library-evolution",
+  //   ])
+  // )
 }


### PR DESCRIPTION
SPM recommends `Package.swift` point to the latest version, but we're doing the opposite.