### PR TITLE
Include Missing Target Dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -47,6 +47,8 @@ let package = Package(
         .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
         .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
         .product(name: "SwiftDiagnostics", package: "swift-syntax"),
+        .product(name: "SwiftSyntax", package: "swift-syntax"),
+        .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
       ]
     ),
     .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -46,6 +46,7 @@ let package = Package(
       dependencies: [
         .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
         .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+        .product(name: "SwiftDiagnostics", package: "swift-syntax"),
       ]
     ),
     .testTarget(

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -47,6 +47,8 @@ let package = Package(
         .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
         .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
         .product(name: "SwiftDiagnostics", package: "swift-syntax"),
+        .product(name: "SwiftSyntax", package: "swift-syntax"),
+        .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
       ]
     ),
     .testTarget(

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -46,6 +46,7 @@ let package = Package(
       dependencies: [
         .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
         .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+        .product(name: "SwiftDiagnostics", package: "swift-syntax"),
       ]
     ),
     .testTarget(


### PR DESCRIPTION
Adds missing target dependencies for a few imports within CasePathsMacros.
I was getting build failures due to these issues on Swift 6.2 SPM (`swift build`).