### PR TITLE
Add swift-parser-diagnostics as direct dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -49,6 +49,7 @@ let package = Package(
         .product(name: "SwiftDiagnostics", package: "swift-syntax"),
         .product(name: "SwiftSyntax", package: "swift-syntax"),
         .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
+        .product(name: "SwiftParserDiagnostics", package: "swift-syntax"),
       ]
     ),
     .testTarget(


### PR DESCRIPTION
Starting in XCode 26.2 I get warnings like:

```
'CasePathsMacros' is missing a dependency on 'SwiftParserDiagnostics' because dependency scan of Swift module 'CasePathsMacros' discovered a dependency on 'SwiftParserDiagnostics'
```

I think this is because indeed that target is not explicitly listed. This PR is my attempt to fix that.