### PR TITLE
Remove warning treatment for Swift 6.4 and above

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -80,9 +80,4 @@ for target in package.targets {
     .enableUpcomingFeature("MemberImportVisibility"),
     .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
   ])
-  #if compiler(>=6.4)
-    target.swiftSettings?.append(contentsOf: [
-      .treatAllWarnings(as: .error)
-    ])
-  #endif
 }


### PR DESCRIPTION
I'm seeing the following error when updating SPM deps in Xcode 27 B1 for an app that depends on TCA26. I noticed the same change recently made in https://github.com/pointfreeco/sqlite-data/commit/d1239ac4847e0d343c8641da12f8f3cb579666de, so this seems like the preferred way to fix it.

```
PackageDescription.SwiftSetting.treatAllWarnings:3:22: note: 'treatAllWarnings(as:_:)' was introduced in Package
Description 6.2
1 | struct SwiftSetting {
2 | @available(_PackageDescription 6.2)
3 |   public static func treatAllWarnings(as level: WarningLevel, _ condition: BuildSettingCondition? = nil) ->
SwiftSetting}
  |                      `- note: 'treatAllWarnings(as:_:)' was introduced in PackageDescription 6.2
4 |
```