### PR TITLE
Add `CasePathable.case`

### DIFF
--- a/Sources/CasePathsCore/CasePathable.swift
+++ b/Sources/CasePathsCore/CasePathable.swift
@@ -493,6 +493,13 @@ extension CasePathable {
   }
 }
 
+extension CasePathable where AllCasePaths: CasePathReflectable<Self> {
+  /// A case key path to this enum's case.
+  public var `case`: PartialCaseKeyPath<Self> {
+    Self.allCasePaths[self]
+  }
+}
+
 extension AnyCasePath {
   /// Creates a type-erased case path for given case key path.
   ///

--- a/Sources/CasePathsCore/Documentation.docc/Extensions/CasePathable.md
+++ b/Sources/CasePathsCore/Documentation.docc/Extensions/CasePathable.md
@@ -14,6 +14,7 @@
 
 ### Case properties
 
+- ``case``
 - ``is(_:)``
 - ``subscript(dynamicMember:)-emck``
 - ``subscript(dynamicMember:)-dm5y``

--- a/Sources/CasePathsCore/Optional+CasePathable.swift
+++ b/Sources/CasePathsCore/Optional+CasePathable.swift
@@ -32,6 +32,7 @@ extension Optional: CasePathable, CasePathIterable {
 
     /// A case path to an optional-chained value.
     @_disfavoredOverload
+    @available(*, deprecated, message: "This subscript will be removed in CasePaths 2.0")
     public subscript<Member>(
       dynamicMember keyPath: KeyPath<Wrapped.AllCasePaths, AnyCasePath<Wrapped, Member>>
     ) -> AnyCasePath<Optional, Member?>

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -60,6 +60,8 @@ final class CasePathsTests: XCTestCase {
   func testCaseKeyPaths() {
     var foo: Foo = .bar(.int(1))
 
+    XCTAssertEqual(foo.case, \.bar)
+
     XCTAssertEqual(foo.bar, .int(1))
     // NB: Due to a Swift bug, this is only possible to do outside the library:
     // XCTAssertEqual(foo.bar?.int, 1)


### PR DESCRIPTION
With the introduction of `CasePathReflectable` we could look up an enum's case statically:

```swift
let enum = Foo.bar
Enum.allCasePaths[enum]  // \.bar
```

Let's make things a little more ergonomic by introducing a `case` property.

As a keyword, `case` is unlikely to conflict with other properties, and it makes enums a little more usable where key path APIs are involved:

```swift
.sheet(item: $enum, id: \.case) { enum in
  // ...
}
```