### PR TITLE
Allow 3rd party macros to expand case paths.

### DIFF
--- a/Sources/CasePathsMacrosSupport/CasePathableMacro.swift
+++ b/Sources/CasePathsMacrosSupport/CasePathableMacro.swift
@@ -9,7 +9,7 @@ public struct CasePathableMacro {
   static let casePathableExpandingMacroNames = [
     "CaseBindable",
     "Table",
-    "Selection"
+    "Selection",
   ]
 
   private static func shouldGenerate(
@@ -24,22 +24,25 @@ public struct CasePathableMacro {
     else { return true }
 
     let hasCasePathableApplied = declaration.attributes.contains {
-      $0.as(AttributeSyntax.self)?.attributeName.as(IdentifierTypeSyntax.self)?.name.text == "CasePathable"
+      $0.as(AttributeSyntax.self)?.attributeName.as(IdentifierTypeSyntax.self)?.name.text
+        == "CasePathable"
     }
-    let firstCasePathableExpandableMacroIndex = casePathableExpandingMacroNames.compactMap { macroName in
+    let firstCasePathableExpandableMacroIndex = casePathableExpandingMacroNames.compactMap {
+      macroName in
       declaration.attributes.firstIndex {
-        $0.as(AttributeSyntax.self)?.attributeName.as(IdentifierTypeSyntax.self)?.name.text ==
-        macroName
+        $0.as(AttributeSyntax.self)?.attributeName.as(IdentifierTypeSyntax.self)?.name.text
+          == macroName
       }
     }
-      .sorted()
-      .first
+    .sorted()
+    .first
     let nodeIndex = declaration.attributes.firstIndex {
-      $0.as(AttributeSyntax.self)?.attributeName.as(IdentifierTypeSyntax.self)?.name.text ==
-      node.attributeName.as(IdentifierTypeSyntax.self)?.name.text ?? ""
+      $0.as(AttributeSyntax.self)?.attributeName.as(IdentifierTypeSyntax.self)?.name.text == node
+        .attributeName.as(IdentifierTypeSyntax.self)?.name.text ?? ""
     }
 
-    return !hasCasePathableApplied && firstCasePathableExpandableMacroIndex == nodeIndex
+    return !hasCasePathableApplied
+      && firstCasePathableExpandableMacroIndex.map { $0 == nodeIndex } ?? true
   }
 }
 
@@ -96,7 +99,8 @@ extension CasePathableMacro: MemberMacro {
   }
 
   public static func expansion<
-    Declaration: DeclGroupSyntax, Context: MacroExpansionContext
+    Declaration: DeclGroupSyntax,
+    Context: MacroExpansionContext
   >(
     of node: AttributeSyntax,
     providingMembersOf declaration: Declaration,
@@ -125,7 +129,8 @@ extension CasePathableMacro: MemberMacro {
         throw DiagnosticsError(
           diagnostics: [
             CasePathableMacroDiagnostic.overloadedCaseName(name).diagnose(
-              at: Syntax(enumCaseDecl.name))
+              at: Syntax(enumCaseDecl.name)
+            )
           ]
         )
       }
@@ -219,7 +224,9 @@ extension CasePathableMacro: MemberMacro {
           let title = "\(decl.poundKeyword.text) \(decl.condition?.description ?? "")"
           return [title]
             + generateDeclSyntax(
-              from: elements, enumName: enumName, elementRewriter: elementRewriter
+              from: elements,
+              enumName: enumName,
+              elementRewriter: elementRewriter
             )
         }
         return ifClauses + ["#endif"]
@@ -311,13 +318,13 @@ enum CasePathableMacroDiagnostic {
 extension CasePathableMacroDiagnostic: DiagnosticMessage {
   var message: String {
     switch self {
-    case let .notAnEnum(decl):
+    case .notAnEnum(let decl):
       return """
         '@CasePathable' cannot be applied to\
         \(decl.keywordDescription.map { " \($0)" } ?? "") type\
         \(decl.nameDescription.map { " '\($0)'" } ?? "")
         """
-    case let .overloadedCaseName(name):
+    case .overloadedCaseName(let name):
       return """
         '@CasePathable' cannot be applied to overloaded case name '\(name)'
         """

--- a/Tests/CasePathsMacrosTests/CasePathsMacrosSupportTests.swift
+++ b/Tests/CasePathsMacrosTests/CasePathsMacrosSupportTests.swift
@@ -10,6 +10,7 @@
       CaseBindableMacro.self,
       CasePathableMacro.self,
       SelectionMacro.self,
+      ThirdPartyMacro.self,
     ])
   )
   struct CasePathsMacrosSupportTests {
@@ -174,7 +175,6 @@
         """#
       }
     }
-
 
     @Test
     func `multiple macros that expand @CasePathable without @CasePathable`() {
@@ -344,6 +344,52 @@
         """#
       }
     }
+
+    @Test func `3rd party macros are allowed to expand case paths`() {
+      assertMacro {
+        """
+        @ThirdParty
+        enum Foo {
+          case baz(Int)
+        }
+        """
+      } expansion: {
+        #"""
+        enum Foo {
+          case baz(Int)
+
+          public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
+            public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
+              if root.is(\.baz) {
+                return \.baz
+              }
+              return \.never
+            }
+            public var baz: CasePaths.AnyCasePath<Foo, Int> {
+              ._$embed(Foo.baz) {
+                guard case let .baz(v0) = $0 else {
+                  return nil
+                }
+                return v0
+              }
+            }
+            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+              var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
+              allCasePaths.append(\.baz)
+              return allCasePaths.makeIterator()
+            }
+          }
+
+          public static var allCasePaths: AllCasePaths {
+            AllCasePaths()
+          }
+        }
+
+        extension Foo: CasePaths.CasePathable, CasePaths.CasePathIterable {
+        }
+        """#
+      }
+    }
   }
 
   private enum SelectionMacro: ExtensionMacro, MemberMacro {
@@ -421,6 +467,36 @@
         """
       )
       return decls
+    }
+  }
+
+  private enum ThirdPartyMacro: ExtensionMacro, MemberMacro {
+    static func expansion(
+      of node: AttributeSyntax,
+      attachedTo declaration: some DeclGroupSyntax,
+      providingExtensionsOf type: some TypeSyntaxProtocol,
+      conformingTo protocols: [TypeSyntax],
+      in context: some MacroExpansionContext
+    ) throws -> [ExtensionDeclSyntax] {
+      try CasePathableMacro.expansion(
+        of: node,
+        attachedTo: declaration,
+        providingExtensionsOf: type,
+        conformingTo: protocols,
+        in: context
+      )
+    }
+    static func expansion(
+      of node: AttributeSyntax,
+      providingMembersOf declaration: some DeclGroupSyntax,
+      conformingTo protocols: [TypeSyntax],
+      in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+      try CasePathableMacro.expansion(
+        of: node,
+        providingMembersOf: declaration,
+        in: context
+      )
     }
   }
 #endif


### PR DESCRIPTION
In #247 we prevented duplication of case path expansions in our own ecosystem of macros, but accidentally prevented 3rd parties from expanding case paths. This fixes that.