### PR TITLE
Add `CasePathable.caseName(for:)`

### DIFF
--- a/Sources/CasePaths/CasePathable.swift
+++ b/Sources/CasePaths/CasePathable.swift
@@ -40,6 +40,16 @@ public protocol CasePathable {
 
   /// A collection of all case paths of this type.
   static var allCasePaths: AllCasePaths { get }
+
+  /// Returns the case name for a given case key path, if available.
+  ///
+  /// - Parameter keyPath: A partial case key path.
+  /// - Returns: The name of the case, or `nil` if the key path doesn't match a known case.
+  static func caseName(for keyPath: PartialCaseKeyPath<Self>) -> String?
+}
+
+extension CasePathable {
+  public static func caseName(for keyPath: PartialCaseKeyPath<Self>) -> String? { nil }
 }
 
 /// A type that is used to distinguish case key paths from key paths by wrapping the enum and

--- a/Sources/CasePaths/Macros.swift
+++ b/Sources/CasePaths/Macros.swift
@@ -32,6 +32,7 @@
   CasePathIterable,
   names: named(AllCasePaths),
   named(allCasePaths),
+  named(caseName),
   named(_$Element)
 )
 public macro CasePathable() =

--- a/Sources/CasePaths/Optional+CasePathable.swift
+++ b/Sources/CasePaths/Optional+CasePathable.swift
@@ -52,6 +52,14 @@ extension Optional: CasePathable, CasePathIterable {
   public static var allCasePaths: AllCasePaths {
     AllCasePaths()
   }
+
+  public static func caseName(for keyPath: PartialCaseKeyPath<Self>) -> String? {
+    switch keyPath {
+    case \.none: return "none"
+    case \.some: return "some"
+    default: return nil
+    }
+  }
 }
 
 extension Case {

--- a/Sources/CasePaths/Result+CasePathable.swift
+++ b/Sources/CasePaths/Result+CasePathable.swift
@@ -33,6 +33,14 @@ extension Result: CasePathable, CasePathIterable {
   public static var allCasePaths: AllCasePaths {
     AllCasePaths()
   }
+
+  public static func caseName(for keyPath: PartialCaseKeyPath<Self>) -> String? {
+    switch keyPath {
+    case \.success: return "success"
+    case \.failure: return "failure"
+    default: return nil
+    }
+  }
 }
 
 extension Result.AllCasePaths: Sequence {

--- a/Sources/CasePathsMacrosSupport/CasePathableMacro.swift
+++ b/Sources/CasePathsMacrosSupport/CasePathableMacro.swift
@@ -146,6 +146,10 @@ extension CasePathableMacro: MemberMacro {
 
     let subscriptReturn = allCases.isEmpty ? #"\.never"# : #"return \.never"#
 
+    let caseNameCases = generateCases(from: memberBlock.members, enumName: enumName) {
+      #"if keyPath == \.\#($0.name.text) { return "\#($0.name.text)" }"#
+    }
+
     var decls: [DeclSyntax] = [
       """
       public \(nonisolated)struct AllCasePaths: \
@@ -164,6 +168,13 @@ extension CasePathableMacro: MemberMacro {
       """,
       """
       public \(nonisolated)static var allCasePaths: AllCasePaths { AllCasePaths() }
+      """,
+      """
+      public \(nonisolated)static func caseName(
+      for keyPath: CasePaths.PartialCaseKeyPath<\(enumName)>
+      ) -> Swift.String? {
+      \(raw: caseNameCases.map { "\($0.description)\n" }.joined())return nil
+      }
       """,
     ]
 

--- a/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
+++ b/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
@@ -1,6 +1,7 @@
 #if os(macOS) && canImport(MacroTesting) && swift(>=6.2)
   import CasePathsMacros
   import MacroTesting
+  import SwiftSyntaxBuilder
   import SwiftSyntaxMacroExpansion
   import SwiftSyntaxMacros
   import XCTest
@@ -101,6 +102,24 @@
           public nonisolated static var allCasePaths: AllCasePaths {
             AllCasePaths()
           }
+
+          public nonisolated static func caseName(
+            for keyPath: CasePaths.PartialCaseKeyPath<Foo>
+          ) -> Swift.String? {
+            if keyPath == \.bar {
+              return "bar"
+            }
+            if keyPath == \.baz {
+              return "baz"
+            }
+            if keyPath == \.fizz {
+              return "fizz"
+            }
+            if keyPath == \.fizzier {
+              return "fizzier"
+            }
+            return nil
+          }
         }
 
         extension Foo: nonisolated CasePathable, nonisolated CasePathIterable {
@@ -131,6 +150,12 @@
 
             public nonisolated static var allCasePaths: AllCasePaths {
                 AllCasePaths()
+            }
+
+            public nonisolated static func caseName(
+                for keyPath: CasePaths.PartialCaseKeyPath<EnumWithNoCases>
+            ) -> Swift.String? {
+                return nil
             }
         }
 
@@ -176,6 +201,15 @@
 
           public nonisolated static var allCasePaths: AllCasePaths {
             AllCasePaths()
+          }
+
+          public nonisolated static func caseName(
+            for keyPath: CasePaths.PartialCaseKeyPath<Foo>
+          ) -> Swift.String? {
+            if keyPath == \.bar {
+              return "bar"
+            }
+            return nil
           }
         }
 
@@ -234,6 +268,18 @@
           public nonisolated static var allCasePaths: AllCasePaths {
             AllCasePaths()
           }
+
+          public nonisolated static func caseName(
+            for keyPath: CasePaths.PartialCaseKeyPath<Foo>
+          ) -> Swift.String? {
+            if keyPath == \.bar {
+              return "bar"
+            }
+            if keyPath == \.baz {
+              return "baz"
+            }
+            return nil
+          }
         }
 
         extension Foo: nonisolated CasePathable, nonisolated CasePathIterable {
@@ -279,6 +325,15 @@
           public nonisolated static var allCasePaths: AllCasePaths {
             AllCasePaths()
           }
+
+          public nonisolated static func caseName(
+            for keyPath: CasePaths.PartialCaseKeyPath<Foo>
+          ) -> Swift.String? {
+            if keyPath == \.bar {
+              return "bar"
+            }
+            return nil
+          }
         }
 
         extension Foo: nonisolated CasePathable, nonisolated CasePathIterable {
@@ -321,6 +376,15 @@
           public nonisolated static var allCasePaths: AllCasePaths {
             AllCasePaths()
           }
+
+          public nonisolated static func caseName(
+            for keyPath: CasePaths.PartialCaseKeyPath<Foo>
+          ) -> Swift.String? {
+            if keyPath == \.bar {
+              return "bar"
+            }
+            return nil
+          }
         }
 
         extension Foo: nonisolated CasePathable, nonisolated CasePathIterable {
@@ -362,6 +426,15 @@
 
           public nonisolated static var allCasePaths: AllCasePaths {
             AllCasePaths()
+          }
+
+          public nonisolated static func caseName(
+            for keyPath: CasePaths.PartialCaseKeyPath<Foo>
+          ) -> Swift.String? {
+            if keyPath == \.bar {
+              return "bar"
+            }
+            return nil
           }
         }
 
@@ -442,6 +515,12 @@
             public nonisolated static var allCasePaths: AllCasePaths {
                 AllCasePaths()
             }
+
+            public nonisolated static func caseName(
+                for keyPath: CasePaths.PartialCaseKeyPath<Foo>
+            ) -> Swift.String? {
+                return nil
+            }
         }
 
         extension Foo: nonisolated CasePathIterable {
@@ -471,6 +550,12 @@
             public nonisolated static var allCasePaths: AllCasePaths {
                 AllCasePaths()
             }
+
+            public nonisolated static func caseName(
+                for keyPath: CasePaths.PartialCaseKeyPath<Foo>
+            ) -> Swift.String? {
+                return nil
+            }
         }
 
         extension Foo: nonisolated CasePathIterable {
@@ -499,6 +584,12 @@
 
             public nonisolated static var allCasePaths: AllCasePaths {
                 AllCasePaths()
+            }
+
+            public nonisolated static func caseName(
+                for keyPath: CasePaths.PartialCaseKeyPath<Foo>
+            ) -> Swift.String? {
+                return nil
             }
         }
 
@@ -545,6 +636,15 @@
           public nonisolated static var allCasePaths: AllCasePaths {
             AllCasePaths()
           }
+
+          public nonisolated static func caseName(
+            for keyPath: CasePaths.PartialCaseKeyPath<Foo>
+          ) -> Swift.String? {
+            if keyPath == \.bar {
+              return "bar"
+            }
+            return nil
+          }
         }
 
         extension Foo: nonisolated CasePathable, nonisolated CasePathIterable {
@@ -590,6 +690,15 @@
           public nonisolated static var allCasePaths: AllCasePaths {
             AllCasePaths()
           }
+
+          public nonisolated static func caseName(
+            for keyPath: CasePaths.PartialCaseKeyPath<Foo>
+          ) -> Swift.String? {
+            if keyPath == \.bar {
+              return "bar"
+            }
+            return nil
+          }
         }
 
         extension Foo: nonisolated CasePathable, nonisolated CasePathIterable {
@@ -634,6 +743,15 @@
 
           public nonisolated static var allCasePaths: AllCasePaths {
             AllCasePaths()
+          }
+
+          public nonisolated static func caseName(
+            for keyPath: CasePaths.PartialCaseKeyPath<Foo>
+          ) -> Swift.String? {
+            if keyPath == \.bar {
+              return "bar"
+            }
+            return nil
           }
         }
 
@@ -832,6 +950,44 @@
           public nonisolated static var allCasePaths: AllCasePaths {
             AllCasePaths()
           }
+
+          public nonisolated static func caseName(
+            for keyPath: CasePaths.PartialCaseKeyPath<Foo>
+          ) -> Swift.String? {
+            if keyPath == \.bar {
+              return "bar"
+            }
+            #if os(macOS)
+            if keyPath == \.macCase {
+              return "macCase"
+            }
+            if keyPath == \.macSecond {
+              return "macSecond"
+            }
+            #elseif os(iOS)
+            if keyPath == \.iosCase {
+              return "iosCase"
+            }
+            #else
+            if keyPath == \.elseCase {
+              return "elseCase"
+            }
+            if keyPath == \.elseLast {
+              return "elseLast"
+            }
+            #endif
+            #if DEBUG
+            #if INNER
+            if keyPath == \.twoLevelsDeep {
+              return "twoLevelsDeep"
+            }
+            if keyPath == \.twoLevels {
+              return "twoLevels"
+            }
+            #endif
+            #endif
+            return nil
+          }
         }
 
         extension Foo: nonisolated CasePathable, nonisolated CasePathIterable {
@@ -881,6 +1037,15 @@
 
           public nonisolated static var allCasePaths: AllCasePaths {
             AllCasePaths()
+          }
+
+          public nonisolated static func caseName(
+            for keyPath: CasePaths.PartialCaseKeyPath<Foo>
+          ) -> Swift.String? {
+            if keyPath == \.bar {
+              return "bar"
+            }
+            return nil
           }
         }
 
@@ -1014,6 +1179,24 @@
           public nonisolated static var allCasePaths: AllCasePaths {
             AllCasePaths()
           }
+
+          public nonisolated static func caseName(
+            for keyPath: CasePaths.PartialCaseKeyPath<Foo>
+          ) -> Swift.String? {
+            if keyPath == \.bar {
+              return "bar"
+            }
+            if keyPath == \.baz {
+              return "baz"
+            }
+            if keyPath == \.fizz {
+              return "fizz"
+            }
+            if keyPath == \.buzz {
+              return "buzz"
+            }
+            return nil
+          }
         }
 
         extension Foo: nonisolated CasePathable, nonisolated CasePathIterable {
@@ -1067,6 +1250,15 @@
 
           public nonisolated static var allCasePaths: AllCasePaths {
             AllCasePaths()
+          }
+
+          public nonisolated static func caseName(
+            for keyPath: CasePaths.PartialCaseKeyPath<Foo>
+          ) -> Swift.String? {
+            if keyPath == \.bar {
+              return "bar"
+            }
+            return nil
           }
         }
 
@@ -1176,6 +1368,27 @@
           public nonisolated static var allCasePaths: AllCasePaths {
             AllCasePaths()
           }
+
+          public nonisolated static func caseName(
+            for keyPath: CasePaths.PartialCaseKeyPath<Foo>
+          ) -> Swift.String? {
+            if keyPath == \.bar {
+              return "bar"
+            }
+            if keyPath == \.baz {
+              return "baz"
+            }
+            if keyPath == \.fizz {
+              return "fizz"
+            }
+            if keyPath == \.fizzier {
+              return "fizzier"
+            }
+            if keyPath == \.fizziest {
+              return "fizziest"
+            }
+            return nil
+          }
         }
 
         extension Foo: nonisolated CasePathable, nonisolated CasePathIterable {
@@ -1220,6 +1433,15 @@
 
           public nonisolated static var allCasePaths: AllCasePaths {
             AllCasePaths()
+          }
+
+          public nonisolated static func caseName(
+            for keyPath: CasePaths.PartialCaseKeyPath<Action>
+          ) -> Swift.String? {
+            if keyPath == \.element {
+              return "element"
+            }
+            return nil
           }
 
           public typealias _$Element = Element
@@ -1272,6 +1494,15 @@
               AllCasePaths()
             }
 
+            public nonisolated static func caseName(
+              for keyPath: CasePaths.PartialCaseKeyPath<Action>
+            ) -> Swift.String? {
+              if keyPath == \.element {
+                return "element"
+              }
+              return nil
+            }
+
             public typealias _$Element = Element
           }
         }
@@ -1318,6 +1549,15 @@
 
           public nonisolated static var allCasePaths: AllCasePaths {
             AllCasePaths()
+          }
+
+          public nonisolated static func caseName(
+            for keyPath: CasePaths.PartialCaseKeyPath<Action>
+          ) -> Swift.String? {
+            if keyPath == \.element {
+              return "element"
+            }
+            return nil
           }
 
           public typealias _$Element = Element
@@ -1393,6 +1633,21 @@
 
           public nonisolated static var allCasePaths: AllCasePaths {
             AllCasePaths()
+          }
+
+          public nonisolated static func caseName(
+            for keyPath: CasePaths.PartialCaseKeyPath<Action>
+          ) -> Swift.String? {
+            if keyPath == \.element {
+              return "element"
+            }
+            if keyPath == \.secondElement {
+              return "secondElement"
+            }
+            if keyPath == \.thirdElement {
+              return "thirdElement"
+            }
+            return nil
           }
 
           public typealias _$Element = Element
@@ -1492,6 +1747,21 @@
 
           public nonisolated static var allCasePaths: AllCasePaths {
             AllCasePaths()
+          }
+
+          public nonisolated static func caseName(
+            for keyPath: CasePaths.PartialCaseKeyPath<Action>
+          ) -> Swift.String? {
+            if keyPath == \.exampleAction {
+              return "exampleAction"
+            }
+            if keyPath == \.singleParam {
+              return "singleParam"
+            }
+            if keyPath == \.multipleWithLabels {
+              return "multipleWithLabels"
+            }
+            return nil
           }
         }
 

--- a/Tests/CasePathsMacrosTests/CasePathsMacrosSupportTests.swift
+++ b/Tests/CasePathsMacrosTests/CasePathsMacrosSupportTests.swift
@@ -2,6 +2,7 @@
   import CasePathsMacrosSupport
   import MacroTesting
   import SwiftSyntax
+  import SwiftSyntaxBuilder
   import SwiftSyntaxMacroExpansion
   import SwiftSyntaxMacros
   import Testing
@@ -95,6 +96,21 @@
             AllCasePaths()
           }
 
+          public nonisolated static func caseName(
+            for keyPath: CasePaths.PartialCaseKeyPath<Foo>
+          ) -> Swift.String? {
+            if keyPath == \.bar {
+              return "bar"
+            }
+            if keyPath == \.baz {
+              return "baz"
+            }
+            if keyPath == \.fizz {
+              return "fizz"
+            }
+            return nil
+          }
+
           public enum BindingEnumeration {
             case bar
             case baz(SwiftUI.Binding<Int>)
@@ -181,6 +197,21 @@
           public nonisolated static var allCasePaths: AllCasePaths {
             AllCasePaths()
           }
+
+          public nonisolated static func caseName(
+            for keyPath: CasePaths.PartialCaseKeyPath<Foo>
+          ) -> Swift.String? {
+            if keyPath == \.bar {
+              return "bar"
+            }
+            if keyPath == \.baz {
+              return "baz"
+            }
+            if keyPath == \.fizz {
+              return "fizz"
+            }
+            return nil
+          }
         }
 
         extension Foo: nonisolated CasePathable, nonisolated CasePathIterable {
@@ -258,6 +289,21 @@
 
           public nonisolated static var allCasePaths: AllCasePaths {
             AllCasePaths()
+          }
+
+          public nonisolated static func caseName(
+            for keyPath: CasePaths.PartialCaseKeyPath<Foo>
+          ) -> Swift.String? {
+            if keyPath == \.bar {
+              return "bar"
+            }
+            if keyPath == \.baz {
+              return "baz"
+            }
+            if keyPath == \.fizz {
+              return "fizz"
+            }
+            return nil
           }
 
           public enum BindingEnumeration {
@@ -345,6 +391,21 @@
             AllCasePaths()
           }
 
+          public nonisolated static func caseName(
+            for keyPath: CasePaths.PartialCaseKeyPath<Foo>
+          ) -> Swift.String? {
+            if keyPath == \.bar {
+              return "bar"
+            }
+            if keyPath == \.baz {
+              return "baz"
+            }
+            if keyPath == \.fizz {
+              return "fizz"
+            }
+            return nil
+          }
+
           public enum BindingEnumeration {
             case bar
             case baz(SwiftUI.Binding<Int>)
@@ -395,6 +456,15 @@
 
           public nonisolated static var allCasePaths: AllCasePaths {
             AllCasePaths()
+          }
+
+          public nonisolated static func caseName(
+            for keyPath: CasePaths.PartialCaseKeyPath<Foo>
+          ) -> Swift.String? {
+            if keyPath == \.baz {
+              return "baz"
+            }
+            return nil
           }
         }
 

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -139,33 +139,6 @@ final class CasePathsTests: XCTestCase {
     XCTAssertEqual(Foo.bar(.int(123)), fooToInt(123))
   }
 
-  func testMatch() {
-    switch Foo.bar(.int(42)) {
-    case \.bar.int:
-      break
-    default:
-      XCTFail()
-    }
-
-    switch Foo.bar(.int(42)) {
-    case \.bar:
-      break
-    default:
-      XCTFail()
-    }
-
-    XCTAssertTrue(Foo.bar(.int(42)).is(\.bar))
-    XCTAssertTrue(Foo.bar(.int(42)).is(\.bar.int))
-    XCTAssertFalse(Foo.bar(.int(42)).is(\.baz))
-    XCTAssertFalse(Foo.bar(.int(42)).is(\.baz.string))
-    XCTAssertFalse(Foo.bar(.int(42)).is(\.blob))
-    XCTAssertFalse(Foo.bar(.int(42)).is(\.fizzBuzz))
-    XCTAssertTrue(Foo.foo(nil).is(\.foo))
-    XCTAssertTrue(Foo.foo(nil).is(\.foo.none))
-    XCTAssertTrue(Foo.foo("").is(\.foo))
-    XCTAssertFalse(Foo.foo(nil).is(\.bar))
-  }
-
   func testPartialCaseKeyPath() {
     let partialPath = \Foo.Cases.bar as PartialCaseKeyPath
     XCTAssertEqual(.bar(.int(42)), partialPath(Bar.int(42)))


### PR DESCRIPTION
This is currently used by TCA26 for better debugging. Draft for now as it is new surface area and we should consider whether the APIs are worth shipping or necessary for the underlying TCA26 functionality.