### PR TITLE
Remove XCTestDynamicOverlay

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,6 @@ let package = Package(
       name: "CasePathsCore",
       dependencies: [
         .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
-        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
       ]
     ),
     .target(

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -38,7 +38,6 @@ let package = Package(
       name: "CasePathsCore",
       dependencies: [
         .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
-        .product(name: "XCTestDynamicOverlay", package: "xctest-dynamic-overlay"),
       ]
     ),
     .macro(

--- a/Sources/CasePaths/Internal/Deprecations.swift
+++ b/Sources/CasePaths/Internal/Deprecations.swift
@@ -1,4 +1,4 @@
-@_spi(CurrentTestCase) import XCTestDynamicOverlay
+import IssueReporting
 
 #if canImport(ObjectiveC)
   import ObjectiveC
@@ -259,11 +259,8 @@ public func XCTUnwrap<Enum, Case>(
   let `enum` = try `enum`()
   guard let value = extract(`enum`)
   else {
-    #if canImport(ObjectiveC)
-      _ = XCTCurrentTestCase?.perform(Selector(("setContinueAfterFailure:")), with: false)
-    #endif
     let message = message()
-    XCTFail(
+    reportIssue(
       """
       XCTUnwrap: Expected to extract value of type "\(typeName(Case.self))" from \
       "\(typeName(Enum.self))"\
@@ -272,7 +269,7 @@ public func XCTUnwrap<Enum, Case>(
         Actual:
           \(String(describing: `enum`))
       """,
-      file: file,
+      filePath: file,
       line: line
     )
     throw UnwrappingCase()

--- a/Sources/CasePaths/XCTestSupport.swift
+++ b/Sources/CasePaths/XCTestSupport.swift
@@ -1,5 +1,5 @@
 import Foundation
-@_spi(CurrentTestCase) import XCTestDynamicOverlay
+import IssueReporting
 
 /// Asserts that an enum value matches a particular case and modifies the associated value in place.
 @available(*, deprecated, message: "Use 'CasePathable.modify' to mutate an expected case, instead.")
@@ -31,16 +31,13 @@ func _XCTModify<Enum, Case>(
   case casePath: AnyCasePath<Enum, Case>,
   _ message: @autoclosure () -> String = "",
   _ body: (inout Case) throws -> Void,
-  file: StaticString = #filePath,
-  line: UInt = #line
+  file: StaticString,
+  line: UInt
 ) {
   guard var value = casePath.extract(from: `enum`)
   else {
-    #if canImport(ObjectiveC)
-      _ = XCTCurrentTestCase?.perform(Selector(("setContinueAfterFailure:")), with: false)
-    #endif
     let message = message()
-    XCTFail(
+    reportIssue(
       """
       XCTModify: Expected to extract value of type "\(typeName(Case.self))" from \
       "\(typeName(Enum.self))"\
@@ -49,7 +46,7 @@ func _XCTModify<Enum, Case>(
         Actual:
           \(`enum`)
       """,
-      file: file,
+      filePath: file,
       line: line
     )
     return
@@ -58,7 +55,7 @@ func _XCTModify<Enum, Case>(
   do {
     try body(&value)
   } catch {
-    XCTFail("Threw error: \(error)", file: file, line: line)
+    reportIssue("Threw error: \(error)", filePath: file, line: line)
     return
   }
 
@@ -66,10 +63,12 @@ func _XCTModify<Enum, Case>(
     let isEqual = _isEqual(before, value),
     isEqual
   {
-    XCTFail(
+    reportIssue(
       """
       XCTModify: Expected "\(typeName(Case.self))" value to be modified but it was unchanged.
-      """
+      """,
+      filePath: file,
+      line: line
     )
   }
 


### PR DESCRIPTION
If we want to expand this library's dependency on IssueReporting to 2.0 we are going to need to remove any reference of XCTestDynamicOverlay. This technically is a small behavioral change since we are dropping `setContinueAfterFailure`, but also it's an API that has been deprecated for years.