### PR TITLE
Add `CasePathsCore.CasePath` protocol

### DIFF
--- a/Sources/CasePaths/Internal/Deprecations.swift
+++ b/Sources/CasePaths/Internal/Deprecations.swift
@@ -294,14 +294,6 @@ public func XCTModify<Enum, Case>(
 
 // Deprecated after 1.0.0:
 
-/// A type-erased case path that supports embedding a value in a root and attempting to extract a
-/// root's embedded value.
-///
-/// This type has been renamed to `AnyCasePath` and is primarily employed by the ``CasePathable()``
-/// macro to derive `CaseKeyPath`s from an enum's cases.
-@available(*, deprecated, renamed: "AnyCasePath")
-public typealias CasePath = AnyCasePath
-
 @available(*, deprecated, message: "Use 'CustomDebugStringConvertible.debugDescription', instead")
 extension AnyCasePath: CustomStringConvertible {
   public var description: String {

--- a/Sources/CasePaths/Macros.swift
+++ b/Sources/CasePaths/Macros.swift
@@ -22,8 +22,8 @@
 /// _: CaseKeyPath<UserAction, SettingsAction> = \.settings
 ///
 /// // Or they can be fully qualified under the type's `Cases`:
-/// \UserAction.Cases.home      // CasePath<UserAction, HomeAction>
-/// \UserAction.Cases.settings  // CasePath<UserAction, SettingsAction>
+/// \UserAction.Cases.home      // AnyCasePath<UserAction, HomeAction>
+/// \UserAction.Cases.settings  // AnyCasePath<UserAction, SettingsAction>
 /// ```
 @attached(extension, conformances: CasePathable, CasePathIterable)
 @attached(member, names: named(AllCasePaths), named(allCasePaths), named(_$Element))

--- a/Sources/CasePathsCore/CasePath.swift
+++ b/Sources/CasePathsCore/CasePath.swift
@@ -1,0 +1,9 @@
+@_documentation(visibility: private)
+public protocol CasePath<Root, Value> {
+  associatedtype Root
+  associatedtype Value
+  func embed(_ value: Value) -> Root
+  func extract(from root: Root) -> Value?
+}
+
+extension AnyCasePath: CasePath {}

--- a/Tests/CasePathsTests/DeprecatedTests.swift
+++ b/Tests/CasePathsTests/DeprecatedTests.swift
@@ -260,12 +260,12 @@ final class DeprecatedTests: XCTestCase {
   #if RELEASE
     func testNonEnumExtract() {
       // This is a bogus CasePath, intended to verify that it just returns nil.
-      let path: CasePath<Int, Int> = /{ $0 }
+      let path: AnyCasePath<Int, Int> = /{ $0 }
 
       for _ in 1...2 {
         XCTAssertNil(path.extract(from: 42))
       }
-      XCTAssertNil(CasePath { $0 }.extract(from: 42))
+      XCTAssertNil(AnyCasePath<Int, Int>({ $0 }).extract(from: 42))
     }
   #endif
 


### PR DESCRIPTION
This will aid in libraries that want to integrate with both CasePaths 1.0 and 2.0. They will be able to make the following change today:

```diff
 import CasePathsCore

-KeyPath<Root.AllCasePaths, AnyCasePath<Root, Value>>
+KeyPath<Root.AllCasePaths, some CasePath<Root, Value>>
```

And 2.0 should work without any changes.