### PR TITLE
Make requirements static to prepare for 2.0

### DIFF
--- a/Sources/CasePathsCore/CasePathIterable.swift
+++ b/Sources/CasePathsCore/CasePathIterable.swift
@@ -2,12 +2,12 @@
 ///
 /// The `@CasePathable` macro automatically generates a conformance to this protocol.
 ///
-/// You can iterate over ``CasePathable/allCasePaths`` to get access to each individual case path:
+/// You can collect ``CasePathable/allCasePaths`` into an array to get access to each case path:
 ///
 /// ```swift
 /// @CasePathable enum Field {
 ///   case title(String)
-///   case body(String
+///   case body(String)
 ///   case isLive
 /// }
 ///

--- a/Sources/CasePathsCore/CasePathReflectable.swift
+++ b/Sources/CasePathsCore/CasePathReflectable.swift
@@ -1,9 +1,8 @@
-/// A type that can reflect a case path from a given case.
+/// A type that can reflect the case paths of an enum.
 ///
 /// The `@CasePathable` macro automatically generates a conformance to this protocol on the enum's
-/// ``CasePathable/AllCasePaths`` type.
-///
-/// You can look up an enum's case path by passing it to ``CasePathReflectable/subscript(_:)``:
+/// ``CasePathable/AllCasePaths`` type, which powers ``CasePathable/case`` and iteration over an
+/// enum's case key paths:
 ///
 /// ```swift
 /// @CasePathable
@@ -13,15 +12,60 @@
 ///   case isLive
 /// }
 ///
-/// Field.allCasePaths[.title("Hello, Blob!")]  // \.title
+/// Field.title("Hello, Blob!").case  // \.title
+/// Array(Field.allCasePaths)         // [\.title, \.body, \.isLive]
 /// ```
+///
+/// You should not need to interact with this protocol directly. Constrain generic code to
+/// ``CasePathable`` instead.
 public protocol CasePathReflectable<Root> {
   /// The enum type that can be reflected.
   associatedtype Root: CasePathable
 
+  static func _case(for root: Root) -> PartialCaseKeyPath<Root>
+
+  static var _allCaseKeyPaths: [PartialCaseKeyPath<Root>] { get }
+
   /// Returns the case key path for a given root value.
   ///
-  /// - Parameter root: An root value.
+  /// - Parameter root: A root value.
   /// - Returns: A case path to the root value.
+  @available(*, deprecated, message: "Use 'root.case' instead")
   subscript(root: Root) -> PartialCaseKeyPath<Root> { get }
+}
+
+extension CasePathReflectable {
+  @available(*, deprecated, message: "Use 'root.case' instead")
+  public subscript(root: Root) -> PartialCaseKeyPath<Root> {
+    root.case
+  }
+}
+
+extension CasePathReflectable where Root.AllCasePaths == Self {
+  @available(*, deprecated, message: "Implement 'static _case(for:)' instead")
+  public static func _case(for root: Root) -> PartialCaseKeyPath<Root> {
+    Root.allCasePaths[root]
+  }
+}
+
+extension CasePathReflectable {
+  @available(*, deprecated, message: "Implement 'static _allCaseKeyPaths' instead")
+  public static var _allCaseKeyPaths: [PartialCaseKeyPath<Root>] {
+    []
+  }
+}
+
+extension CasePathReflectable
+where Self: Sequence, Element == PartialCaseKeyPath<Root>, Root.AllCasePaths == Self {
+  @available(*, deprecated, message: "Implement 'static _allCaseKeyPaths' instead")
+  public static var _allCaseKeyPaths: [PartialCaseKeyPath<Root>] {
+    Array(Root.allCasePaths)
+  }
+}
+
+extension CasePathReflectable where Self: Sequence, Element == PartialCaseKeyPath<Root> {
+  @available(*, deprecated, message: "Iterate over 'Array(Enum.allCasePaths)' instead")
+  public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Root>]> {
+    Self._allCaseKeyPaths.makeIterator()
+  }
 }

--- a/Sources/CasePathsCore/CasePathable.swift
+++ b/Sources/CasePathsCore/CasePathable.swift
@@ -32,6 +32,17 @@ import IssueReporting
 ///   }
 ///
 ///   public static var allCasePaths: AllCasePaths { AllCasePaths() }
+///
+///   public var `case`: PartialCaseKeyPath<Self> {
+///     switch self {
+///     case .success: return \.success
+///     case .failure: return \.failure
+///     }
+///   }
+///
+///   public static var _allCaseKeyPaths: [PartialCaseKeyPath<Self>] {
+///     [\.success, \.failure]
+///   }
 /// }
 /// ```
 public protocol CasePathable {
@@ -40,6 +51,22 @@ public protocol CasePathable {
 
   /// A collection of all case paths of this type.
   static var allCasePaths: AllCasePaths { get }
+
+  /// A case key path to this enum's case.
+  ///
+  /// ```swift
+  /// @CasePathable
+  /// enum Field {
+  ///   case title(String)
+  ///   case body(String)
+  ///   case isLive
+  /// }
+  ///
+  /// Field.title("Hello, Blob!").case  // \.title
+  /// ```
+  var `case`: PartialCaseKeyPath<Self> { get }
+
+  static var _allCaseKeyPaths: [PartialCaseKeyPath<Self>] { get }
 }
 
 /// A type that is used to distinguish case key paths from key paths by wrapping the enum and
@@ -494,9 +521,12 @@ extension CasePathable {
 }
 
 extension CasePathable where AllCasePaths: CasePathReflectable<Self> {
-  /// A case key path to this enum's case.
   public var `case`: PartialCaseKeyPath<Self> {
-    Self.allCasePaths[self]
+    AllCasePaths._case(for: self)
+  }
+
+  public static var _allCaseKeyPaths: [PartialCaseKeyPath<Self>] {
+    AllCasePaths._allCaseKeyPaths
   }
 }
 

--- a/Sources/CasePathsCore/Never+CasePathable.swift
+++ b/Sources/CasePathsCore/Never+CasePathable.swift
@@ -1,7 +1,11 @@
 extension Never: CasePathable, CasePathIterable {
   public struct AllCasePaths: CasePathReflectable, Sendable {
-    public subscript(root: Never) -> PartialCaseKeyPath<Never> {
+    public static func _case(for root: Never) -> PartialCaseKeyPath<Never> {
       \.never
+    }
+
+    public static var _allCaseKeyPaths: [PartialCaseKeyPath<Never>] {
+      []
     }
   }
 
@@ -30,7 +34,8 @@ extension Case {
 }
 
 extension Never.AllCasePaths: Sequence {
-  public func makeIterator() -> some IteratorProtocol<PartialCaseKeyPath<Never>> {
-    [].makeIterator()
+  @available(*, deprecated, message: "Iterate over 'Array(Never.allCasePaths)' instead")
+  public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Never>]> {
+    Self._allCaseKeyPaths.makeIterator()
   }
 }

--- a/Sources/CasePathsCore/Optional+CasePathable.swift
+++ b/Sources/CasePathsCore/Optional+CasePathable.swift
@@ -1,11 +1,15 @@
 extension Optional: CasePathable, CasePathIterable {
   @dynamicMemberLookup
   public struct AllCasePaths: CasePathReflectable, Sendable {
-    public subscript(root: Optional) -> PartialCaseKeyPath<Optional> {
+    public static func _case(for root: Optional) -> PartialCaseKeyPath<Optional> {
       switch root {
       case .none: return \.none
       case .some: return \.some
       }
+    }
+
+    public static var _allCaseKeyPaths: [PartialCaseKeyPath<Optional>] {
+      [\.none, \.some]
     }
 
     /// A case path to the absence of a value.
@@ -69,8 +73,9 @@ extension Case {
 }
 
 extension Optional.AllCasePaths: Sequence {
-  public func makeIterator() -> some IteratorProtocol<PartialCaseKeyPath<Optional>> {
-    [\.none, \.some].makeIterator()
+  @available(*, deprecated, message: "Iterate over 'Array(Optional.allCasePaths)' instead")
+  public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Optional>]> {
+    Self._allCaseKeyPaths.makeIterator()
   }
 }
 

--- a/Sources/CasePathsCore/Result+CasePathable.swift
+++ b/Sources/CasePathsCore/Result+CasePathable.swift
@@ -1,10 +1,14 @@
 extension Result: CasePathable, CasePathIterable {
   public struct AllCasePaths: CasePathReflectable, Sendable {
-    public subscript(root: Result) -> PartialCaseKeyPath<Result> {
+    public static func _case(for root: Result) -> PartialCaseKeyPath<Result> {
       switch root {
       case .success: return \.success
       case .failure: return \.failure
       }
+    }
+
+    public static var _allCaseKeyPaths: [PartialCaseKeyPath<Result>] {
+      [\.success, \.failure]
     }
 
     /// A success case path, for embedding or extracting a `Success` value.
@@ -36,7 +40,8 @@ extension Result: CasePathable, CasePathIterable {
 }
 
 extension Result.AllCasePaths: Sequence {
-  public func makeIterator() -> some IteratorProtocol<PartialCaseKeyPath<Result>> {
-    [\.success, \.failure].makeIterator()
+  @available(*, deprecated, message: "Iterate over 'Array(Result.allCasePaths)' instead")
+  public func makeIterator() -> IndexingIterator<[PartialCaseKeyPath<Result>]> {
+    Self._allCaseKeyPaths.makeIterator()
   }
 }

--- a/Sources/CasePathsMacrosSupport/CasePathableMacro.swift
+++ b/Sources/CasePathsMacrosSupport/CasePathableMacro.swift
@@ -140,7 +140,7 @@ extension CasePathableMacro: MemberMacro {
     let selfRewriter = SelfRewriter(selfEquivalent: enumName)
     let memberBlock = selfRewriter.rewrite(enumDecl.memberBlock).cast(MemberBlockSyntax.self)
     let rootSubscriptCases = generateCases(from: memberBlock.members, enumName: enumName) {
-      "if root.is(\\.\($0.name.text)) { return \\.\($0.name.text) }"
+      "if case .\($0.name.text) = root { return \\.\($0.name.text) }"
     }
     let elementRewriter = ElementRewriter()
     let casePaths = generateDeclSyntax(
@@ -157,15 +157,15 @@ extension CasePathableMacro: MemberMacro {
     var decls: [DeclSyntax] = [
       """
       public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-      public subscript(root: \(enumName)) -> CasePaths.PartialCaseKeyPath<\(enumName)> {
+      public static func _case(for root: \(enumName)) -> CasePaths.PartialCaseKeyPath<\(enumName)> {
       \(raw: rootSubscriptCases.map { "\($0.description)\n" }.joined())\(raw: subscriptReturn)
       }
       \(raw: casePaths.map(\.description).joined(separator: "\n"))
-      public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<\(enumName)>]> {
+      public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<\(enumName)>] {
       \(raw: allCases.isEmpty ? "let" : "var") allCasePaths: \
       [CasePaths.PartialCaseKeyPath<\(enumName)>] = []\
       \(raw: allCases.map { "\n\($0.description)" }.joined())
-      return allCasePaths.makeIterator()
+      return allCasePaths
       }
       }
       """,

--- a/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
+++ b/Tests/CasePathsMacrosTests/CasePathableMacroTests.swift
@@ -33,17 +33,17 @@
           case fizzier(Int, buzzier: String)
 
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-            public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
-              if root.is(\.bar) {
+            public static func _case(for root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
+              if case .bar = root {
                 return \.bar
               }
-              if root.is(\.baz) {
+              if case .baz = root {
                 return \.baz
               }
-              if root.is(\.fizz) {
+              if case .fizz = root {
                 return \.fizz
               }
-              if root.is(\.fizzier) {
+              if case .fizzier = root {
                 return \.fizzier
               }
               return \.never
@@ -82,13 +82,13 @@
                 return (v0, v1)
               }
             }
-            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Foo>] {
               var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
               allCasePaths.append(\.bar)
               allCasePaths.append(\.baz)
               allCasePaths.append(\.fizz)
               allCasePaths.append(\.fizzier)
-              return allCasePaths.makeIterator()
+              return allCasePaths
             }
           }
 
@@ -113,13 +113,13 @@
         enum EnumWithNoCases {
 
             public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-                public subscript(root: EnumWithNoCases) -> CasePaths.PartialCaseKeyPath<EnumWithNoCases> {
+                public static func _case(for root: EnumWithNoCases) -> CasePaths.PartialCaseKeyPath<EnumWithNoCases> {
                     \.never
                 }
 
-                public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<EnumWithNoCases>]> {
+                public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<EnumWithNoCases>] {
                     let allCasePaths: [CasePaths.PartialCaseKeyPath<EnumWithNoCases>] = []
-                    return allCasePaths.makeIterator()
+                    return allCasePaths
                 }
             }
 
@@ -147,8 +147,8 @@
           case bar(Never)
 
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-            public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
-              if root.is(\.bar) {
+            public static func _case(for root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
+              if case .bar = root {
                 return \.bar
               }
               return \.never
@@ -161,10 +161,10 @@
                 return v0
               }
             }
-            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Foo>] {
               var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
               allCasePaths.append(\.bar)
-              return allCasePaths.makeIterator()
+              return allCasePaths
             }
           }
 
@@ -192,11 +192,11 @@
           case bar(Int), baz(String)
 
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-            public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
-              if root.is(\.bar) {
+            public static func _case(for root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
+              if case .bar = root {
                 return \.bar
               }
-              if root.is(\.baz) {
+              if case .baz = root {
                 return \.baz
               }
               return \.never
@@ -217,11 +217,11 @@
                 return v0
               }
             }
-            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Foo>] {
               var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
               allCasePaths.append(\.bar)
               allCasePaths.append(\.baz)
-              return allCasePaths.makeIterator()
+              return allCasePaths
             }
           }
 
@@ -249,8 +249,8 @@
           case bar(Int)
 
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-            public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
-              if root.is(\.bar) {
+            public static func _case(for root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
+              if case .bar = root {
                 return \.bar
               }
               return \.never
@@ -263,10 +263,10 @@
                 return v0
               }
             }
-            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Foo>] {
               var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
               allCasePaths.append(\.bar)
-              return allCasePaths.makeIterator()
+              return allCasePaths
             }
           }
 
@@ -291,8 +291,8 @@
           case bar(Int)
 
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-            public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
-              if root.is(\.bar) {
+            public static func _case(for root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
+              if case .bar = root {
                 return \.bar
               }
               return \.never
@@ -305,10 +305,10 @@
                 return v0
               }
             }
-            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Foo>] {
               var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
               allCasePaths.append(\.bar)
-              return allCasePaths.makeIterator()
+              return allCasePaths
             }
           }
 
@@ -333,8 +333,8 @@
           case bar(Int)
 
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-            public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
-              if root.is(\.bar) {
+            public static func _case(for root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
+              if case .bar = root {
                 return \.bar
               }
               return \.never
@@ -347,10 +347,10 @@
                 return v0
               }
             }
-            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Foo>] {
               var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
               allCasePaths.append(\.bar)
-              return allCasePaths.makeIterator()
+              return allCasePaths
             }
           }
 
@@ -412,13 +412,13 @@
         enum Foo: CasePathable {
 
             public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-                public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
+                public static func _case(for root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
                     \.never
                 }
 
-                public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+                public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Foo>] {
                     let allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
-                    return allCasePaths.makeIterator()
+                    return allCasePaths
                 }
             }
 
@@ -441,13 +441,13 @@
         enum Foo: CasePaths.CasePathable {
 
             public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-                public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
+                public static func _case(for root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
                     \.never
                 }
 
-                public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+                public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Foo>] {
                     let allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
-                    return allCasePaths.makeIterator()
+                    return allCasePaths
                 }
             }
 
@@ -475,8 +475,8 @@
           case bar(_ int: Int, _ bool: Bool)
 
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-            public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
-              if root.is(\.bar) {
+            public static func _case(for root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
+              if case .bar = root {
                 return \.bar
               }
               return \.never
@@ -489,10 +489,10 @@
                 return (v0, v1)
               }
             }
-            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Foo>] {
               var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
               allCasePaths.append(\.bar)
-              return allCasePaths.makeIterator()
+              return allCasePaths
             }
           }
 
@@ -520,8 +520,8 @@
           case bar(Bar<Self>)
 
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-            public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
-              if root.is(\.bar) {
+            public static func _case(for root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
+              if case .bar = root {
                 return \.bar
               }
               return \.never
@@ -534,10 +534,10 @@
                 return v0
               }
             }
-            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Foo>] {
               var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
               allCasePaths.append(\.bar)
-              return allCasePaths.makeIterator()
+              return allCasePaths
             }
           }
 
@@ -565,8 +565,8 @@
           case bar(int: Int = 42, bool: Bool = true)
 
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-            public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
-              if root.is(\.bar) {
+            public static func _case(for root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
+              if case .bar = root {
                 return \.bar
               }
               return \.never
@@ -579,10 +579,10 @@
                 return (v0, v1)
               }
             }
-            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Foo>] {
               var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
               allCasePaths.append(\.bar)
-              return allCasePaths.makeIterator()
+              return allCasePaths
             }
           }
 
@@ -644,35 +644,35 @@
           #endif
 
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-            public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
-              if root.is(\.bar) {
+            public static func _case(for root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
+              if case .bar = root {
                 return \.bar
               }
               #if os(macOS)
-              if root.is(\.macCase) {
+              if case .macCase = root {
                 return \.macCase
               }
-              if root.is(\.macSecond) {
+              if case .macSecond = root {
                 return \.macSecond
               }
               #elseif os(iOS)
-              if root.is(\.iosCase) {
+              if case .iosCase = root {
                 return \.iosCase
               }
               #else
-              if root.is(\.elseCase) {
+              if case .elseCase = root {
                 return \.elseCase
               }
-              if root.is(\.elseLast) {
+              if case .elseLast = root {
                 return \.elseLast
               }
               #endif
               #if DEBUG
               #if INNER
-              if root.is(\.twoLevelsDeep) {
+              if case .twoLevelsDeep = root {
                 return \.twoLevelsDeep
               }
-              if root.is(\.twoLevels) {
+              if case .twoLevels = root {
                 return \.twoLevels
               }
               #endif
@@ -761,7 +761,7 @@
             }
             #endif
             #endif
-            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Foo>] {
               var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
               allCasePaths.append(\.bar)
               #if os(macOS)
@@ -779,7 +779,7 @@
               allCasePaths.append(\.twoLevels)
               #endif
               #endif
-              return allCasePaths.makeIterator()
+              return allCasePaths
             }
           }
 
@@ -810,8 +810,8 @@
           case bar
 
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-            public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
-              if root.is(\.bar) {
+            public static func _case(for root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
+              if case .bar = root {
                 return \.bar
               }
               return \.never
@@ -826,10 +826,10 @@
                 return ()
               }
             }
-            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Foo>] {
               var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
               allCasePaths.append(\.bar)
-              return allCasePaths.makeIterator()
+              return allCasePaths
             }
           }
 
@@ -886,17 +886,17 @@
           case fizz, buzz
 
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-            public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
-              if root.is(\.bar) {
+            public static func _case(for root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
+              if case .bar = root {
                 return \.bar
               }
-              if root.is(\.baz) {
+              if case .baz = root {
                 return \.baz
               }
-              if root.is(\.fizz) {
+              if case .fizz = root {
                 return \.fizz
               }
-              if root.is(\.buzz) {
+              if case .buzz = root {
                 return \.buzz
               }
               return \.never
@@ -955,13 +955,13 @@
                 return ()
               }
             }
-            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Foo>] {
               var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
               allCasePaths.append(\.bar)
               allCasePaths.append(\.baz)
               allCasePaths.append(\.fizz)
               allCasePaths.append(\.buzz)
-              return allCasePaths.makeIterator()
+              return allCasePaths
             }
           }
 
@@ -994,8 +994,8 @@
           case bar
 
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-            public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
-              if root.is(\.bar) {
+            public static func _case(for root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
+              if case .bar = root {
                 return \.bar
               }
               return \.never
@@ -1012,10 +1012,10 @@
                 return ()
               }
             }
-            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Foo>] {
               var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
               allCasePaths.append(\.bar)
-              return allCasePaths.makeIterator()
+              return allCasePaths
             }
           }
 
@@ -1053,20 +1053,20 @@
           case fizziest // Comment without associated value
 
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-            public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
-              if root.is(\.bar) {
+            public static func _case(for root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
+              if case .bar = root {
                 return \.bar
               }
-              if root.is(\.baz) {
+              if case .baz = root {
                 return \.baz
               }
-              if root.is(\.fizz) {
+              if case .fizz = root {
                 return \.fizz
               }
-              if root.is(\.fizzier) {
+              if case .fizzier = root {
                 return \.fizzier
               }
-              if root.is(\.fizziest) {
+              if case .fizziest = root {
                 return \.fizziest
               }
               return \.never
@@ -1116,14 +1116,14 @@
                 return ()
               }
             }
-            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Foo>] {
               var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
               allCasePaths.append(\.bar)
               allCasePaths.append(\.baz)
               allCasePaths.append(\.fizz)
               allCasePaths.append(\.fizzier)
               allCasePaths.append(\.fizziest)
-              return allCasePaths.makeIterator()
+              return allCasePaths
             }
           }
 
@@ -1151,8 +1151,8 @@
           case element(Element)
 
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-            public subscript(root: Action) -> CasePaths.PartialCaseKeyPath<Action> {
-              if root.is(\.element) {
+            public static func _case(for root: Action) -> CasePaths.PartialCaseKeyPath<Action> {
+              if case .element = root {
                 return \.element
               }
               return \.never
@@ -1165,10 +1165,10 @@
                 return v0
               }
             }
-            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Action>]> {
+            public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Action>] {
               var allCasePaths: [CasePaths.PartialCaseKeyPath<Action>] = []
               allCasePaths.append(\.element)
-              return allCasePaths.makeIterator()
+              return allCasePaths
             }
           }
 
@@ -1201,8 +1201,8 @@
             case element(Element)
 
             public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-              public subscript(root: Action) -> CasePaths.PartialCaseKeyPath<Action> {
-                if root.is(\.element) {
+              public static func _case(for root: Action) -> CasePaths.PartialCaseKeyPath<Action> {
+                if case .element = root {
                   return \.element
                 }
                 return \.never
@@ -1215,10 +1215,10 @@
                   return v0
                 }
               }
-              public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Action>]> {
+              public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Action>] {
                 var allCasePaths: [CasePaths.PartialCaseKeyPath<Action>] = []
                 allCasePaths.append(\.element)
-                return allCasePaths.makeIterator()
+                return allCasePaths
               }
             }
 
@@ -1249,8 +1249,8 @@
           case element(Array<Element>)
 
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-            public subscript(root: Action) -> CasePaths.PartialCaseKeyPath<Action> {
-              if root.is(\.element) {
+            public static func _case(for root: Action) -> CasePaths.PartialCaseKeyPath<Action> {
+              if case .element = root {
                 return \.element
               }
               return \.never
@@ -1263,10 +1263,10 @@
                 return v0
               }
             }
-            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Action>]> {
+            public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Action>] {
               var allCasePaths: [CasePaths.PartialCaseKeyPath<Action>] = []
               allCasePaths.append(\.element)
-              return allCasePaths.makeIterator()
+              return allCasePaths
             }
           }
 
@@ -1300,14 +1300,14 @@
           case thirdElement(Element, Element, Int)
 
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-            public subscript(root: Action) -> CasePaths.PartialCaseKeyPath<Action> {
-              if root.is(\.element) {
+            public static func _case(for root: Action) -> CasePaths.PartialCaseKeyPath<Action> {
+              if case .element = root {
                 return \.element
               }
-              if root.is(\.secondElement) {
+              if case .secondElement = root {
                 return \.secondElement
               }
-              if root.is(\.thirdElement) {
+              if case .thirdElement = root {
                 return \.thirdElement
               }
               return \.never
@@ -1336,12 +1336,12 @@
                 return (v0, v1, v2)
               }
             }
-            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Action>]> {
+            public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Action>] {
               var allCasePaths: [CasePaths.PartialCaseKeyPath<Action>] = []
               allCasePaths.append(\.element)
               allCasePaths.append(\.secondElement)
               allCasePaths.append(\.thirdElement)
-              return allCasePaths.makeIterator()
+              return allCasePaths
             }
           }
 
@@ -1395,14 +1395,14 @@
           )
 
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-            public subscript(root: Action) -> CasePaths.PartialCaseKeyPath<Action> {
-              if root.is(\.exampleAction) {
+            public static func _case(for root: Action) -> CasePaths.PartialCaseKeyPath<Action> {
+              if case .exampleAction = root {
                 return \.exampleAction
               }
-              if root.is(\.singleParam) {
+              if case .singleParam = root {
                 return \.singleParam
               }
-              if root.is(\.multipleWithLabels) {
+              if case .multipleWithLabels = root {
                 return \.multipleWithLabels
               }
               return \.never
@@ -1435,12 +1435,12 @@
                 return (v0, v1, v2)
               }
             }
-            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Action>]> {
+            public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Action>] {
               var allCasePaths: [CasePaths.PartialCaseKeyPath<Action>] = []
               allCasePaths.append(\.exampleAction)
               allCasePaths.append(\.singleParam)
               allCasePaths.append(\.multipleWithLabels)
-              return allCasePaths.makeIterator()
+              return allCasePaths
             }
           }
 

--- a/Tests/CasePathsMacrosTests/CasePathsMacrosSupportTests.swift
+++ b/Tests/CasePathsMacrosTests/CasePathsMacrosSupportTests.swift
@@ -31,14 +31,14 @@
           case fizz(buzz: String)
 
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-            public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
-              if root.is(\.bar) {
+            public static func _case(for root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
+              if case .bar = root {
                 return \.bar
               }
-              if root.is(\.baz) {
+              if case .baz = root {
                 return \.baz
               }
-              if root.is(\.fizz) {
+              if case .fizz = root {
                 return \.fizz
               }
               return \.never
@@ -69,12 +69,12 @@
                 return v0
               }
             }
-            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Foo>] {
               var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
               allCasePaths.append(\.bar)
               allCasePaths.append(\.baz)
               allCasePaths.append(\.fizz)
-              return allCasePaths.makeIterator()
+              return allCasePaths
             }
           }
 
@@ -118,14 +118,14 @@
           }
 
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-            public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
-              if root.is(\.bar) {
+            public static func _case(for root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
+              if case .bar = root {
                 return \.bar
               }
-              if root.is(\.baz) {
+              if case .baz = root {
                 return \.baz
               }
-              if root.is(\.fizz) {
+              if case .fizz = root {
                 return \.fizz
               }
               return \.never
@@ -156,12 +156,12 @@
                 return v0
               }
             }
-            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Foo>] {
               var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
               allCasePaths.append(\.bar)
               allCasePaths.append(\.baz)
               allCasePaths.append(\.fizz)
-              return allCasePaths.makeIterator()
+              return allCasePaths
             }
           }
 
@@ -196,14 +196,14 @@
           case fizz(buzz: String)
 
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-            public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
-              if root.is(\.bar) {
+            public static func _case(for root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
+              if case .bar = root {
                 return \.bar
               }
-              if root.is(\.baz) {
+              if case .baz = root {
                 return \.baz
               }
-              if root.is(\.fizz) {
+              if case .fizz = root {
                 return \.fizz
               }
               return \.never
@@ -234,12 +234,12 @@
                 return v0
               }
             }
-            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Foo>] {
               var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
               allCasePaths.append(\.bar)
               allCasePaths.append(\.baz)
               allCasePaths.append(\.fizz)
-              return allCasePaths.makeIterator()
+              return allCasePaths
             }
           }
 
@@ -281,14 +281,14 @@
           case fizz(buzz: String)
 
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-            public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
-              if root.is(\.bar) {
+            public static func _case(for root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
+              if case .bar = root {
                 return \.bar
               }
-              if root.is(\.baz) {
+              if case .baz = root {
                 return \.baz
               }
-              if root.is(\.fizz) {
+              if case .fizz = root {
                 return \.fizz
               }
               return \.never
@@ -319,12 +319,12 @@
                 return v0
               }
             }
-            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Foo>] {
               var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
               allCasePaths.append(\.bar)
               allCasePaths.append(\.baz)
               allCasePaths.append(\.fizz)
-              return allCasePaths.makeIterator()
+              return allCasePaths
             }
           }
 
@@ -359,8 +359,8 @@
           case baz(Int)
 
           public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
-            public subscript(root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
-              if root.is(\.baz) {
+            public static func _case(for root: Foo) -> CasePaths.PartialCaseKeyPath<Foo> {
+              if case .baz = root {
                 return \.baz
               }
               return \.never
@@ -373,10 +373,10 @@
                 return v0
               }
             }
-            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Foo>]> {
+            public static var _allCaseKeyPaths: [CasePaths.PartialCaseKeyPath<Foo>] {
               var allCasePaths: [CasePaths.PartialCaseKeyPath<Foo>] = []
               allCasePaths.append(\.baz)
-              return allCasePaths.makeIterator()
+              return allCasePaths
             }
           }
 

--- a/Tests/CasePathsTests/CasePathsTests.swift
+++ b/Tests/CasePathsTests/CasePathsTests.swift
@@ -24,10 +24,10 @@ final class CasePathsTests: XCTestCase {
     let fizzBuzzPath3 = \Fizz.Cases.buzz.fizzBuzz.int
     XCTAssertNotEqual(fizzBuzzPath1, fizzBuzzPath3)
     XCTAssertEqual(fizzBuzzPath2, fizzBuzzPath3)
-    XCTAssertEqual(Optional.allCasePaths[Int?.some(42)], \.some)
-    XCTAssertNotEqual(Optional.allCasePaths[Int?.some(42)], \.none)
-    XCTAssertEqual(Optional.allCasePaths[Int?.none], \.none)
-    XCTAssertNotEqual(Optional.allCasePaths[Int?.none], \.some)
+    XCTAssertEqual(Int?.some(42).case, \.some)
+    XCTAssertNotEqual(Int?.some(42).case, \.none)
+    XCTAssertEqual(Int?.none.case, \.none)
+    XCTAssertNotEqual(Int?.none.case, \.some)
   }
 
   func testResult() {
@@ -38,10 +38,10 @@ final class CasePathsTests: XCTestCase {
     XCTAssertNotNil(Result<Int, Error>.failure(SomeError())[case: \.failure])
     XCTAssertEqual((\Result<Int, SomeError>.Cases.success)(42), .success(42))
     XCTAssertEqual((\Result<Int, SomeError>.Cases.failure)(SomeError()), .failure(SomeError()))
-    XCTAssertEqual(Result.allCasePaths[Result<Int, Error>.success(42)], \.success)
-    XCTAssertNotEqual(Result.allCasePaths[Result<Int, Error>.success(42)], \.failure)
-    XCTAssertEqual(Result.allCasePaths[Result<Int, Error>.failure(SomeError())], \.failure)
-    XCTAssertNotEqual(Result.allCasePaths[Result<Int, Error>.failure(SomeError())], \.success)
+    XCTAssertEqual(Result<Int, Error>.success(42).case, \.success)
+    XCTAssertNotEqual(Result<Int, Error>.success(42).case, \.failure)
+    XCTAssertEqual(Result<Int, Error>.failure(SomeError()).case, \.failure)
+    XCTAssertNotEqual(Result<Int, Error>.failure(SomeError()).case, \.success)
   }
 
   func testSelfCaseKeyPathCallAsFunction() {
@@ -95,10 +95,10 @@ final class CasePathsTests: XCTestCase {
     XCTAssertEqual((\Foo.Cases.bar.int)(1), .bar(.int(1)))
     XCTAssertEqual((\Foo.Cases.fizzBuzz)(), .fizzBuzz)
 
-    XCTAssertEqual(Foo.allCasePaths[.bar(.int(1))], \.bar)
-    XCTAssertEqual(Foo.allCasePaths[.baz(.string(""))], \.baz)
-    XCTAssertEqual(Foo.allCasePaths[.fizzBuzz], \.fizzBuzz)
-    XCTAssertEqual(Foo.allCasePaths[.foo(nil)], \.foo)
+    XCTAssertEqual(Foo.bar(.int(1)).case, \.bar)
+    XCTAssertEqual(Foo.baz(.string("")).case, \.baz)
+    XCTAssertEqual(Foo.fizzBuzz.case, \.fizzBuzz)
+    XCTAssertEqual(Foo.foo(nil).case, \.foo)
 
     XCTAssertEqual(
       Array(Foo.allCasePaths),

--- a/Tests/CasePathsTests/CaseSetTests.swift
+++ b/Tests/CasePathsTests/CaseSetTests.swift
@@ -8,10 +8,9 @@
 
     public init() {}
 
-    public init(_ elements: some Collection<Element>)
-    where Element.AllCasePaths: CasePathReflectable<Element> {
+    public init(_ elements: some Collection<Element>) {
       self.storage = [PartialCaseKeyPath<Element> & Sendable: Element](
-        uniqueKeysWithValues: elements.map { (Element.allCasePaths[$0], $0) }
+        uniqueKeysWithValues: elements.map { ($0.case, $0) }
       )
     }
 
@@ -46,7 +45,7 @@
   }
 
   extension CaseSet: SetAlgebra
-  where Element: Equatable, Element.AllCasePaths: CasePathReflectable<Element> {
+  where Element: Equatable {
     public var isEmpty: Bool { storage.isEmpty }
 
     public func union(_ other: CaseSet<Element>) -> CaseSet<Element> {
@@ -71,18 +70,18 @@
     public mutating func insert(
       _ newMember: Element
     ) -> (inserted: Bool, memberAfterInsert: Element) {
-      let inserted = storage.updateValue(newMember, forKey: Element.allCasePaths[newMember]) == nil
+      let inserted = storage.updateValue(newMember, forKey: newMember.case) == nil
       return (inserted, newMember)
     }
 
     @discardableResult
     public mutating func remove(_ member: Element) -> Element? {
-      storage.removeValue(forKey: Element.allCasePaths[member])
+      storage.removeValue(forKey: member.case)
     }
 
     @discardableResult
     public mutating func update(with newMember: Element) -> Element? {
-      let inserted = storage.updateValue(newMember, forKey: Element.allCasePaths[newMember]) == nil
+      let inserted = storage.updateValue(newMember, forKey: newMember.case) == nil
       return inserted ? nil : newMember
     }
 
@@ -114,7 +113,7 @@
   extension CaseSet: @unchecked Sendable where Element: Sendable {}
 
   extension CaseSet: Decodable
-  where Element: Decodable, Element.AllCasePaths: CasePathReflectable<Element> {
+  where Element: Decodable {
     public init(from decoder: any Decoder) throws {
       var container = try decoder.unkeyedContainer()
       if let count = container.count {
@@ -122,7 +121,7 @@
       }
       while !container.isAtEnd {
         let element = try container.decode(Element.self)
-        if let original = storage.updateValue(element, forKey: Element.allCasePaths[element]) {
+        if let original = storage.updateValue(element, forKey: element.case) {
           throw DecodingError.dataCorrupted(
             DecodingError.Context(
               codingPath: container.codingPath,
@@ -143,8 +142,7 @@
     }
   }
 
-  extension CaseSet: ExpressibleByArrayLiteral
-  where Element.AllCasePaths: CasePathReflectable<Element> {
+  extension CaseSet: ExpressibleByArrayLiteral {
     public init(arrayLiteral elements: Element...) {
       self.init(elements)
     }

--- a/Tests/CasePathsTests/DeprecatedTests.swift
+++ b/Tests/CasePathsTests/DeprecatedTests.swift
@@ -5,8 +5,36 @@ protocol TestProtocol: Sendable {}
 extension Int: TestProtocol {}
 protocol TestClassProtocol: AnyObject {}
 
+@CasePathable
+private enum ReflectableEnum: Equatable {
+  case bar(Int)
+  case baz
+}
+
 @available(*, deprecated)
 final class DeprecatedTests: XCTestCase {
+  func testInstanceReflection() {
+    struct SomeError: Error {}
+    XCTAssertEqual(ReflectableEnum.allCasePaths[.bar(1)], \.bar)
+    XCTAssertEqual(ReflectableEnum.allCasePaths[.baz], \.baz)
+    XCTAssertEqual(Optional.allCasePaths[Int?.some(42)], \.some)
+    XCTAssertEqual(Optional.allCasePaths[Int?.none], \.none)
+    XCTAssertEqual(Result<Int, Error>.allCasePaths[.success(42)], \.success)
+    XCTAssertEqual(Result<Int, Error>.allCasePaths[.failure(SomeError())], \.failure)
+  }
+
+  func testIteration() {
+    var casePaths: [PartialCaseKeyPath<ReflectableEnum>] = []
+    for casePath in ReflectableEnum.allCasePaths {
+      casePaths.append(casePath)
+    }
+    XCTAssertEqual(casePaths, [\.bar, \.baz])
+    XCTAssertEqual(ReflectableEnum.allCasePaths.map { $0 }, [\.bar, \.baz])
+    XCTAssertEqual(Optional<Int>.allCasePaths.map { $0 }, [\.none, \.some])
+    XCTAssertEqual(Result<Int, Error>.allCasePaths.map { $0 }, [\.success, \.failure])
+    XCTAssertEqual(Never.allCasePaths.map { $0 }, [])
+  }
+
   func testSimplePayload() {
     enum Enum { case payload(Int) }
     let path: AnyCasePath<Enum, Int> = /Enum.payload


### PR DESCRIPTION
Currently, completing from a case key path from `\.` returns a bunch of extra endpoints due to the `Sequence` requirements of `AllCasePaths` leaking through, as well as the subscript used to look up the case path for a particular case:

- `lazy`
- `publisher`
- `underestimatedCount`
- `[_:]`

This is a lot of noise that gets in the way, so let's rethink things:

- Iterating over all of an enum's case paths now requires an explicit `Array(Enum.allCasePaths)`.
- Getting a particular case of an enum is already achievable via `enum.case`, so we can make that the main requirement.